### PR TITLE
fix(dropdown,list): font type (#DS-2461)

### DIFF
--- a/packages/design-tokens/web/components/list.json5
+++ b/packages/design-tokens/web/components/list.json5
@@ -37,9 +37,9 @@
         },
         font: {
             text: { value: 'text-normal' },
-            caption: { value: 'text-compact'},
-            header: { value: 'subheading'},
-            subheading: { value: 'caps-compact'},
+            caption: { value: 'text-compact' },
+            subheading: { value: 'caps-compact-strong' },
+            header: { value: 'text-big-strong' }
         },
         light: {
             default: {


### PR DESCRIPTION
## Summary

Fixed font types for `subheading` and `header`

Result:
![image](https://github.com/koobiq/design-tokens/assets/42917304/90790b5b-fa0c-4976-99ac-a4d2ed7e834e)
