### PR TITLE
Empty-state: fix typography and paddings (#DS-2619)

### DIFF
--- a/packages/design-tokens/web/components/empty-state.json5
+++ b/packages/design-tokens/web/components/empty-state.json5
@@ -18,7 +18,7 @@
                     height: { value: '{size.6xl}' }
                 },
                 title: {
-                    'margin-bottom': { value: '{size.xl}' },
+                    'margin-bottom': { value: '{size.l}' },
                 }
             },
             normal: {
@@ -32,13 +32,13 @@
                     'margin-top': { value: '{size.s}' }
                 },
                 image: {
-                    'margin-bottom': { value: '{size.3xl}' }
+                    'margin-bottom': { value: '{size.xl}' }
                 },
                 'image-addon': {
                     height: { value: '{size.xxl}' }
                 },
                 title: {
-                    'margin-bottom': { value: '{size.s}' },
+                    'margin-bottom': { value: '{size.xxs}' },
                 }
             },
         },
@@ -65,13 +65,13 @@
             },
             normal: {
                 title: {
-                    "font-size": { value: '{typography.subheading.font-size}' },
-                    "line-height": { value: '{typography.subheading.line-height}' },
-                    "letter-spacing": { value: '{typography.subheading.letter-spacing}' },
-                    "font-weight": { value: '{typography.subheading.font-weight}' },
-                    "font-family": { value: '{typography.subheading.font-family}' },
-                    "text-transform": { value: '{typography.subheading.text-transform}' },
-                    "font-feature-settings": { value: '{typography.subheading.font-feature-settings}' }
+                    "font-size": { value: '{typography.text-big-strong.font-size}' },
+                    "line-height": { value: '{typography.text-big-strong.line-height}' },
+                    "letter-spacing": { value: '{typography.text-big-strong.letter-spacing}' },
+                    "font-weight": { value: '{typography.text-big-strong.font-weight}' },
+                    "font-family": { value: '{typography.text-big-strong.font-family}' },
+                    "text-transform": { value: '{typography.text-big-strong.text-transform}' },
+                    "font-feature-settings": { value: '{typography.text-big-strong.font-feature-settings}' }
                 },
                 text: {
                     "font-size": { value: '{typography.text-normal.font-size}' },


### PR DESCRIPTION
Поправил стили текста и отступы с учетом новой типографики
https://www.figma.com/design/xzvLO9WNSWB8ESnzQbsMEK/branch/L0XnEIJZdqzC7m071AcXRa/Empty-State-Placeholder?node-id=2002-16938&t=cmdhenPRlIUvDcgD-11

![изображение](https://github.com/user-attachments/assets/82deb3aa-590c-489e-8c1d-d53b84647bc2)

