### PR TITLE
feat: transformed theme-specific global vars to theme-agnostic (#DS-2755)

### DIFF
--- a/packages/tokens-builder/filters/css-variables.js
+++ b/packages/tokens-builder/filters/css-variables.js
@@ -15,12 +15,12 @@ module.exports = (StyleDictionary) => {
 
     StyleDictionary.registerFilter({
         name: 'css-variables-light',
-        matcher: (prop) => prop.attributes.light
+        matcher: (prop) => prop.attributes.light && !prop.attributes.palette
     });
 
     StyleDictionary.registerFilter({
         name: 'css-variables-dark',
-        matcher: (prop) => prop.attributes.dark
+        matcher: (prop) => prop.attributes.dark && !prop.attributes.palette
     });
 
     StyleDictionary.registerFilter({

--- a/packages/tokens-builder/transforms/attribute/theme.js
+++ b/packages/tokens-builder/transforms/attribute/theme.js
@@ -3,7 +3,11 @@ module.exports = (StyleDictionary) => {
         name: 'kbq-attribute/light',
         type: 'attribute',
         matcher: ({ attributes }) => {
-            return (attributes.category === 'markdown' && attributes.item === 'light') || attributes.type === 'light';
+            return (
+                (attributes.category === 'markdown' && attributes.item === 'light') ||
+                attributes.type === 'light' ||
+                attributes.category === 'light'
+            );
         },
         transformer: () => ({ light: true })
     });
@@ -12,7 +16,11 @@ module.exports = (StyleDictionary) => {
         name: 'kbq-attribute/dark',
         type: 'attribute',
         matcher: ({ attributes }) => {
-            return (attributes.category === 'markdown' && attributes.item === 'dark') || attributes.type === 'dark';
+            return (
+                (attributes.category === 'markdown' && attributes.item === 'dark') ||
+                attributes.type === 'dark' ||
+                attributes.category === 'dark'
+            );
         },
         transformer: () => ({ dark: true })
     });


### PR DESCRIPTION
### Theming unified
Global semantic colors have been placed under theme selectors and prefixes for variables removed - so they do not depend on the theme. For example:

**Before**
```
// css-tokens.css
--kbq-light-theme-default: color;
--kbq-dark-theme-default: otherColor;
```

**After**
```
// css-tokens-light.css
.kbq-light {
   --kbq-theme-default: color;
   ... other theme specific colors
}
```

```
// css-tokens-dark.css
.kbq-light {
   --kbq-theme-default: otherColor;
   ... other theme specific colors
}
```
