### PR TITLE
fix(typography): font-weight for strong (#DS-2762)

### DIFF
--- a/packages/design-tokens/web/components/badge.json5
+++ b/packages/design-tokens/web/components/badge.json5
@@ -250,13 +250,13 @@
         font: {
             normal: {
                 default: {
-                    'font-size': { value: '{typography.text-normal-strong.font-size}' },
-                    'line-height': { value: '{typography.text-normal-strong.line-height}' },
-                    'letter-spacing': { value: '{typography.text-normal-strong.letter-spacing}' },
-                    'font-weight': { value: '{typography.text-normal-strong.font-weight}' },
-                    'font-family': { value: '{typography.text-normal-strong.font-family}' },
-                    'text-transform': { value: '{typography.text-normal-strong.text-transform}' },
-                    'font-feature-settings': { value: '{typography.text-normal-strong.font-feature-settings}' }
+                    'font-size': { value: '{typography.text-normal-medium.font-size}' },
+                    'line-height': { value: '{typography.text-normal-medium.line-height}' },
+                    'letter-spacing': { value: '{typography.text-normal-medium.letter-spacing}' },
+                    'font-weight': { value: '{typography.text-normal-medium.font-weight}' },
+                    'font-family': { value: '{typography.text-normal-medium.font-family}' },
+                    'text-transform': { value: '{typography.text-normal-medium.text-transform}' },
+                    'font-feature-settings': { value: '{typography.text-normal-medium.font-feature-settings}' }
                 },
                 caption: {
                     'font-size': { value: '{typography.text-normal.font-size}' },
@@ -270,13 +270,13 @@
             },
             compact: {
                 default: {
-                    'font-size': { value: '{typography.text-compact-strong.font-size}' },
-                    'line-height': { value: '{typography.text-compact-strong.line-height}' },
-                    'letter-spacing': { value: '{typography.text-compact-strong.letter-spacing}' },
-                    'font-weight': { value: '{typography.text-compact-strong.font-weight}' },
-                    'font-family': { value: '{typography.text-compact-strong.font-family}' },
-                    'text-transform': { value: '{typography.text-compact-strong.text-transform}' },
-                    'font-feature-settings': { value: '{typography.text-compact-strong.font-feature-settings}' }
+                    'font-size': { value: '{typography.text-compact-medium.font-size}' },
+                    'line-height': { value: '{typography.text-compact-medium.line-height}' },
+                    'letter-spacing': { value: '{typography.text-compact-medium.letter-spacing}' },
+                    'font-weight': { value: '{typography.text-compact-medium.font-weight}' },
+                    'font-family': { value: '{typography.text-compact-medium.font-family}' },
+                    'text-transform': { value: '{typography.text-compact-medium.text-transform}' },
+                    'font-feature-settings': { value: '{typography.text-compact-medium.font-feature-settings}' }
                 },
                 caption: {
                     'font-size': { value: '{typography.text-compact.font-size}' },

--- a/packages/design-tokens/web/components/button-toggle.json5
+++ b/packages/design-tokens/web/components/button-toggle.json5
@@ -32,13 +32,13 @@
         },
         font: {
             item: {
-                "font-size": { value: '{typography.text-normal-strong.font-size}' },
-                "line-height": { value: '{typography.text-normal-strong.line-height}' },
-                "letter-spacing": { value: '{typography.text-normal-strong.letter-spacing}' },
-                "font-weight": { value: '{typography.text-normal-strong.font-weight}' },
-                "font-family": { value: '{typography.text-normal-strong.font-family}' },
-                "text-transform": { value: '{typography.text-normal-strong.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-normal-strong.font-feature-settings}' }
+                "font-size": { value: '{typography.text-normal-medium.font-size}' },
+                "line-height": { value: '{typography.text-normal-medium.line-height}' },
+                "letter-spacing": { value: '{typography.text-normal-medium.letter-spacing}' },
+                "font-weight": { value: '{typography.text-normal-medium.font-weight}' },
+                "font-family": { value: '{typography.text-normal-medium.font-family}' },
+                "text-transform": { value: '{typography.text-normal-medium.text-transform}' },
+                "font-feature-settings": { value: '{typography.text-normal-medium.font-feature-settings}' }
             }
         },
         light: {

--- a/packages/design-tokens/web/components/button.json5
+++ b/packages/design-tokens/web/components/button.json5
@@ -9,13 +9,13 @@
         },
         font: {
             default: {
-                "font-size": { value: '{typography.text-normal-strong.font-size}' },
-                "line-height": { value: '{typography.text-normal-strong.line-height}' },
-                "letter-spacing": { value: '{typography.text-normal-strong.letter-spacing}' },
-                "font-weight": { value: '{typography.text-normal-strong.font-weight}' },
-                "font-family": { value: '{typography.text-normal-strong.font-family}' },
-                "text-transform": { value: '{typography.text-normal-strong.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-normal-strong.font-feature-settings}' }
+                "font-size": { value: '{typography.text-normal-medium.font-size}' },
+                "line-height": { value: '{typography.text-normal-medium.line-height}' },
+                "letter-spacing": { value: '{typography.text-normal-medium.letter-spacing}' },
+                "font-weight": { value: '{typography.text-normal-medium.font-weight}' },
+                "font-family": { value: '{typography.text-normal-medium.font-family}' },
+                "text-transform": { value: '{typography.text-normal-medium.text-transform}' },
+                "font-feature-settings": { value: '{typography.text-normal-medium.font-feature-settings}' }
             },
         },
         light: {

--- a/packages/design-tokens/web/components/hint.json5
+++ b/packages/design-tokens/web/components/hint.json5
@@ -89,24 +89,24 @@
         font: {
             normal: {
                  text: {
-                     "font-size": { value: '{typography.text-normal-strong.font-size}' },
-                     "line-height": { value: '{typography.text-normal-strong.line-height}' },
-                     "letter-spacing": { value: '{typography.text-normal-strong.letter-spacing}' },
-                     "font-weight": { value: '{typography.text-normal-strong.font-weight}' },
-                     "font-family": { value: '{typography.text-normal-strong.font-family}' },
-                     "text-transform": { value: '{typography.text-normal-strong.text-transform}' },
-                     "font-feature-settings": { value: '{typography.text-normal-strong.font-feature-settings}' }
+                     "font-size": { value: '{typography.text-normal-medium.font-size}' },
+                     "line-height": { value: '{typography.text-normal-medium.line-height}' },
+                     "letter-spacing": { value: '{typography.text-normal-medium.letter-spacing}' },
+                     "font-weight": { value: '{typography.text-normal-medium.font-weight}' },
+                     "font-family": { value: '{typography.text-normal-medium.font-family}' },
+                     "text-transform": { value: '{typography.text-normal-medium.text-transform}' },
+                     "font-feature-settings": { value: '{typography.text-normal-medium.font-feature-settings}' }
                  }
             },
             compact: {
                  text: {
-                     "font-size": { value: '{typography.text-compact-strong.font-size}' },
-                     "line-height": { value: '{typography.text-compact-strong.line-height}' },
-                     "letter-spacing": { value: '{typography.text-compact-strong.letter-spacing}' },
-                     "font-weight": { value: '{typography.text-compact-strong.font-weight}' },
-                     "font-family": { value: '{typography.text-compact-strong.font-family}' },
-                     "text-transform": { value: '{typography.text-compact-strong.text-transform}' },
-                     "font-feature-settings": { value: '{typography.text-compact-strong.font-feature-settings}' }
+                     "font-size": { value: '{typography.text-compact.font-size}' },
+                     "line-height": { value: '{typography.text-compact.line-height}' },
+                     "letter-spacing": { value: '{typography.text-compact.letter-spacing}' },
+                     "font-weight": { value: '{typography.text-compact.font-weight}' },
+                     "font-family": { value: '{typography.text-compact.font-family}' },
+                     "text-transform": { value: '{typography.text-compact.text-transform}' },
+                     "font-feature-settings": { value: '{typography.text-compact.font-feature-settings}' }
                  }
             }
         }

--- a/packages/design-tokens/web/components/tabs.json5
+++ b/packages/design-tokens/web/components/tabs.json5
@@ -32,13 +32,13 @@
         },
         font: {
             text: {
-                'font-size': { value: '{typography.text-normal-strong.font-size}' },
-                'line-height': { value: '{typography.text-normal-strong.line-height}' },
-                'letter-spacing': { value: '{typography.text-normal-strong.letter-spacing}' },
-                'font-weight': { value: '{typography.text-normal-strong.font-weight}' },
-                'font-family': { value: '{typography.text-normal-strong.font-family}' },
-                'text-transform': { value: '{typography.text-normal-strong.text-transform}' },
-                'font-feature-settings': { value: '{typography.text-normal-strong.font-feature-settings}' }
+                'font-size': { value: '{typography.text-normal-medium.font-size}' },
+                'line-height': { value: '{typography.text-normal-medium.line-height}' },
+                'letter-spacing': { value: '{typography.text-normal-medium.letter-spacing}' },
+                'font-weight': { value: '{typography.text-normal-medium.font-weight}' },
+                'font-family': { value: '{typography.text-normal-medium.font-family}' },
+                'text-transform': { value: '{typography.text-normal-medium.text-transform}' },
+                'font-feature-settings': { value: '{typography.text-normal-medium.font-feature-settings}' }
             }
         },
         light: {

--- a/packages/design-tokens/web/components/tag.json5
+++ b/packages/design-tokens/web/components/tag.json5
@@ -18,13 +18,13 @@
         },
         font: {
             default: {
-                "font-size": { value: '{typography.text-normal-strong.font-size}' },
-                "line-height": { value: '{typography.text-normal-strong.line-height}' },
-                "letter-spacing": { value: '{typography.text-normal-strong.letter-spacing}' },
-                "font-weight": { value: '{typography.text-normal-strong.font-weight}' },
-                "font-family": { value: '{typography.text-normal-strong.font-family}' },
-                "text-transform": { value: '{typography.text-normal-strong.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-normal-strong.font-feature-settings}' }
+                "font-size": { value: '{typography.text-normal-medium.font-size}' },
+                "line-height": { value: '{typography.text-normal-medium.line-height}' },
+                "letter-spacing": { value: '{typography.text-normal-medium.letter-spacing}' },
+                "font-weight": { value: '{typography.text-normal-medium.font-weight}' },
+                "font-family": { value: '{typography.text-normal-medium.font-family}' },
+                "text-transform": { value: '{typography.text-normal-medium.text-transform}' },
+                "font-feature-settings": { value: '{typography.text-normal-medium.font-feature-settings}' }
             }
         },
         // Стили

--- a/packages/design-tokens/web/components/tooltip.json5
+++ b/packages/design-tokens/web/components/tooltip.json5
@@ -24,13 +24,13 @@
                 "font-feature-settings": { value: '{typography.text-compact.font-feature-settings}' }
             },
             title: {
-               "font-size": { value: '{typography.text-compact-strong.font-size}' },
-                "line-height": { value: '{typography.text-compact-strong.line-height}' },
-                "letter-spacing": { value: '{typography.text-compact-strong.letter-spacing}' },
-                "font-weight": { value: '{typography.text-compact-strong.font-weight}' },
-                "font-family": { value: '{typography.text-compact-strong.font-family}' },
-                "text-transform": { value: '{typography.text-compact-strong.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-compact-strong.font-feature-settings}' } 
+               "font-size": { value: '{typography.text-compact.font-size}' },
+                "line-height": { value: '{typography.text-compact.line-height}' },
+                "letter-spacing": { value: '{typography.text-compact.letter-spacing}' },
+                "font-weight": { value: '{typography.text-compact.font-weight}' },
+                "font-family": { value: '{typography.text-compact.font-family}' },
+                "text-transform": { value: '{typography.text-compact.text-transform}' },
+                "font-feature-settings": { value: '{typography.text-compact.font-feature-settings}' } 
             }
         },
         light: {

--- a/packages/design-tokens/web/properties/typography.json5
+++ b/packages/design-tokens/web/properties/typography.json5
@@ -312,7 +312,7 @@
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
         },
-        'text-big-strong': {
+        'text-big-medium': {
             "font-size": { value: '16px' },
             "line-height": { value: '24px' },
             "letter-spacing": { value: '-0.011em' },
@@ -321,7 +321,7 @@
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
         },
-        'text-big-bold': {
+        'text-big-strong': {
             "font-size": { value: '16px' },
             "line-height": { value: '24px' },
             "letter-spacing": { value: '-0.011em' },
@@ -339,7 +339,7 @@
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
         },
-        "text-normal-strong": {
+        "text-normal-medium": {
             "font-size": { value: '14px' },
             "line-height": { value: '20px' },
             "letter-spacing": { value: '-0.006em' },
@@ -348,7 +348,7 @@
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
         },
-        "text-normal-bold": {
+        "text-normal-strong": {
             "font-size": { value: '14px' },
             "line-height": { value: '20px' },
             "letter-spacing": { value: '-0.006em' },
@@ -366,7 +366,7 @@
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
         },
-        "text-compact-strong": {
+        "text-compact-medium": {
             "font-size": { value: '12px' },
             "line-height": { value: '16px' },
             "letter-spacing": { value: 'normal' },
@@ -375,7 +375,7 @@
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
         },
-        "text-compact-bold": {
+        "text-compact-strong": {
             "font-size": { value: '12px' },
             "line-height": { value: '16px' },
             "letter-spacing": { value: 'normal' },

--- a/packages/design-tokens/web/properties/typography.json5
+++ b/packages/design-tokens/web/properties/typography.json5
@@ -113,7 +113,7 @@
             "font-size": { value: '16px' },
             "line-height": { value: '24px' },
             "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
@@ -123,7 +123,7 @@
             "font-size": { value: '16px' },
             "line-height": { value: '24px' },
             "letter-spacing": { value: '0.08em' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '400' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'uppercase' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
@@ -143,7 +143,7 @@
             "font-size": { value: '16px' },
             "line-height": { value: '24px' },
             "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '700' },
             "font-family": { value: '{font.family.mono}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: 'initial' }
@@ -173,7 +173,7 @@
             "font-size": { value: '14px' },
             "line-height": { value: '20px' },
             "letter-spacing": { value: '-0.006em' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
@@ -203,7 +203,7 @@
             "font-size": { value: '14px' },
             "line-height": { value: '20px' },
             "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '700' },
             "font-family": { value: '{font.family.mono}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: 'initial' }
@@ -223,7 +223,7 @@
             "font-size": { value: '12px' },
             "line-height": { value: '16px' },
             "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
@@ -316,6 +316,15 @@
             "font-size": { value: '16px' },
             "line-height": { value: '24px' },
             "letter-spacing": { value: '-0.011em' },
+            "font-weight": { value: '500' },
+            "font-family": { value: '{font.family.base}' },
+            "text-transform": { value: 'null' },
+            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
+        },
+        'text-big-bold': {
+            "font-size": { value: '16px' },
+            "line-height": { value: '24px' },
+            "letter-spacing": { value: '-0.011em' },
             "font-weight": { value: '600' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
@@ -331,6 +340,15 @@
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
         },
         "text-normal-strong": {
+            "font-size": { value: '14px' },
+            "line-height": { value: '20px' },
+            "letter-spacing": { value: '-0.006em' },
+            "font-weight": { value: '500' },
+            "font-family": { value: '{font.family.base}' },
+            "text-transform": { value: 'null' },
+            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
+        },
+        "text-normal-bold": {
             "font-size": { value: '14px' },
             "line-height": { value: '20px' },
             "letter-spacing": { value: '-0.006em' },
@@ -352,6 +370,15 @@
             "font-size": { value: '12px' },
             "line-height": { value: '16px' },
             "letter-spacing": { value: 'normal' },
+            "font-weight": { value: '500' },
+            "font-family": { value: '{font.family.base}' },
+            "text-transform": { value: 'null' },
+            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
+        },
+        "text-compact-bold": {
+            "font-size": { value: '12px' },
+            "line-height": { value: '16px' },
+            "letter-spacing": { value: 'normal' },
             "font-weight": { value: '600' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
@@ -370,7 +397,7 @@
             "font-size": { value: '16px' },
             "line-height": { value: '24px' },
             "letter-spacing": { value: '0.08em' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'uppercase' },
             "font-feature-settings": { value: '"calt", "case", "kern", "liga", "ss01", "ss04"' }
@@ -388,7 +415,7 @@
             "font-size": { value: '14px' },
             "line-height": { value: '20px' },
             "letter-spacing": { value: '0.08em' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'uppercase' },
             "font-feature-settings": { value: '"calt", "case", "kern", "liga", "ss01", "ss04"' }
@@ -406,7 +433,7 @@
             "font-size": { value: '12px' },
             "line-height": { value: '16px' },
             "letter-spacing": { value: '1px' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'uppercase' },
             "font-feature-settings": { value: '"calt", "case", "kern", "liga", "ss01", "ss04"' }
@@ -488,7 +515,7 @@
             "font-size": { value: '16px' },
             "line-height": { value: '24px' },
             "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "ss01", "ss04", "tnum"' }
@@ -506,7 +533,7 @@
             "font-size": { value: '14px' },
             "line-height": { value: '20px' },
             "letter-spacing": { value: '-0.006em' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "ss01", "ss04", "tnum"' }
@@ -524,7 +551,7 @@
             "font-size": { value: '12px' },
             "line-height": { value: '16px' },
             "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "ss01", "ss04", "tnum"' }
@@ -544,7 +571,7 @@
             "font-size": { value: '16px' },
             "line-height": { value: '24px' },
             "letter-spacing": { value: '-0.011em' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
@@ -564,7 +591,7 @@
             "font-size": { value: '14px' },
             "line-height": { value: '20px' },
             "letter-spacing": { value: '-0.006em' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
@@ -584,7 +611,7 @@
             "font-size": { value: '12px' },
             "line-height": { value: '16px' },
             "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '600' },
+            "font-weight": { value: '500' },
             "font-family": { value: '{font.family.base}' },
             "text-transform": { value: 'null' },
             "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }


### PR DESCRIPTION
**ЗАДАЧА**

Кнопки, табы стали сильно жирные с начертанием Semibold (600) у стиля text-strong. Дизайнеры жалуются: раньше с жирностью Medium (500) было лучше, но вместе с тем, Medium не был заметен в абзаце текста. 

Надо исправить это и вместе с тем удовлетворить запрос на то, чтобы можно было выделить текст жирным в абзаце текста.

**CHANGELOG**

1) Add -medium styles. Inter Medium, weight 500
2) Apply -medium to buttons, tabs and so on
3) -strong styles remain unchanged. used them in alert compact header, empty state compact header  

**TO REVIEW**

Bold styles naming in code and Figma

**Code**
<img width="460" alt="изображение" src="https://github.com/user-attachments/assets/0c0ad45d-2cb1-418f-8556-91a80b1bce72">

**Figma**
<img width="249" alt="изображение" src="https://github.com/user-attachments/assets/fc67bffe-e2f7-4363-86d2-b510372e5d15">
