### PR TITLE
feat(colors): added new tokens and updated contrast-fade for our lines

### DIFF
--- a/packages/design-tokens/web/components/link.json5
+++ b/packages/design-tokens/web/components/link.json5
@@ -2,65 +2,65 @@
     link: {
         light: {
             text: { value: '{light.foreground.theme}' },
-            'border-bottom': { value: '{light.line.theme-fade}' },
+            'border-bottom': { value: '{light.line.theme-less}' },
             'state-visited': {
-                'text': { value: '{light.foreground.visited}' },
+                text: { value: '{light.foreground.visited}' },
                 'border-bottom': { value: '{light.line.visited}' }
             },
             'state-visited-hover': {
-                'text': { value: '{light.states.foreground.visited-hover}' },
+                text: { value: '{light.states.foreground.visited-hover}' },
                 'border-bottom': { value: '{light.line.visited}' }
             },
             'state-visited-active': {
-                'text': { value: '{light.states.foreground.visited-active}' },
+                text: { value: '{light.states.foreground.visited-active}' },
                 'border-bottom': { value: '{light.line.visited}' }
             },
             'state-hover': {
-                'text': { value: '{light.states.foreground.theme-hover}' },
-                'border-bottom': { value: '{light.line.theme-fade}' },
+                text: { value: '{light.states.foreground.theme-hover}' },
+                'border-bottom': { value: '{light.line.theme-less}' }
             },
             'state-active': {
-                'text': { value: '{light.states.foreground.theme-active}' },
-                'border-bottom': { value: '{light.line.theme-fade}' },
+                text: { value: '{light.states.foreground.theme-active}' },
+                'border-bottom': { value: '{light.line.theme-less}' }
             },
             'state-focused': {
                 outline: { value: '{light.states.line.focus-theme}' }
             },
-             'state-disabled': {
-                'text': { value: '{light.states.foreground.disabled}' },
-                'border-bottom': { value: '{light.states.line.disabled}' },
-            },
+            'state-disabled': {
+                text: { value: '{light.states.foreground.disabled}' },
+                'border-bottom': { value: '{light.states.line.disabled}' }
+            }
         },
         dark: {
             text: { value: '{dark.foreground.theme}' },
-            'border-bottom': { value: '{dark.line.theme-fade}' },
+            'border-bottom': { value: '{dark.line.theme-less}' },
             'state-visited': {
-                'text': { value: '{dark.foreground.visited}' },
+                text: { value: '{dark.foreground.visited}' },
                 'border-bottom': { value: '{dark.line.visited}' }
             },
             'state-visited-hover': {
-                'text': { value: '{dark.states.foreground.visited-hover}' },
+                text: { value: '{dark.states.foreground.visited-hover}' },
                 'border-bottom': { value: '{dark.line.visited}' }
             },
             'state-visited-active': {
-                'text': { value: '{dark.states.foreground.visited-active}' },
+                text: { value: '{dark.states.foreground.visited-active}' },
                 'border-bottom': { value: '{dark.line.visited}' }
             },
             'state-hover': {
-                'text': { value: '{dark.states.foreground.theme-hover}' },
-                'border-bottom': { value: '{dark.line.theme-fade}' },
+                text: { value: '{dark.states.foreground.theme-hover}' },
+                'border-bottom': { value: '{dark.line.theme-less}' }
             },
             'state-active': {
-                'text': { value: '{dark.states.foreground.theme-active}' },
-                'border-bottom': { value: '{dark.line.theme-fade}' },
+                text: { value: '{dark.states.foreground.theme-active}' },
+                'border-bottom': { value: '{dark.line.theme-less}' }
             },
             'state-focused': {
                 outline: { value: '{dark.states.line.focus-theme}' }
             },
-             'state-disabled': {
-                'text': { value: '{dark.states.foreground.disabled}' },
-                'border-bottom': { value: '{dark.states.line.disabled}' },
-            },
+            'state-disabled': {
+                text: { value: '{dark.states.foreground.disabled}' },
+                'border-bottom': { value: '{dark.states.line.disabled}' }
+            }
         },
         size: {
             'state-focused': {
@@ -79,31 +79,31 @@
         },
         font: {
             compact: {
-                "font-size": { value: '{typography.text-compact.font-size}' },
-                "line-height": { value: '{typography.text-compact.line-height}' },
-                "letter-spacing": { value: '{typography.text-compact.letter-spacing}' },
-                "font-weight": { value: '{typography.text-compact.font-weight}' },
-                "font-family": { value: '{typography.text-compact.font-family}' },
-                "text-transform": { value: '{typography.text-compact.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-compact.font-feature-settings}' }
+                'font-size': { value: '{typography.text-compact.font-size}' },
+                'line-height': { value: '{typography.text-compact.line-height}' },
+                'letter-spacing': { value: '{typography.text-compact.letter-spacing}' },
+                'font-weight': { value: '{typography.text-compact.font-weight}' },
+                'font-family': { value: '{typography.text-compact.font-family}' },
+                'text-transform': { value: '{typography.text-compact.text-transform}' },
+                'font-feature-settings': { value: '{typography.text-compact.font-feature-settings}' }
             },
             normal: {
-                "font-size": { value: '{typography.text-normal.font-size}' },
-                "line-height": { value: '{typography.text-normal.line-height}' },
-                "letter-spacing": { value: '{typography.text-normal.letter-spacing}' },
-                "font-weight": { value: '{typography.text-normal.font-weight}' },
-                "font-family": { value: '{typography.text-normal.font-family}' },
-                "text-transform": { value: '{typography.text-normal.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-normal.font-feature-settings}' }
+                'font-size': { value: '{typography.text-normal.font-size}' },
+                'line-height': { value: '{typography.text-normal.line-height}' },
+                'letter-spacing': { value: '{typography.text-normal.letter-spacing}' },
+                'font-weight': { value: '{typography.text-normal.font-weight}' },
+                'font-family': { value: '{typography.text-normal.font-family}' },
+                'text-transform': { value: '{typography.text-normal.text-transform}' },
+                'font-feature-settings': { value: '{typography.text-normal.font-feature-settings}' }
             },
             big: {
-                "font-size": { value: '{typography.text-big.font-size}' },
-                "line-height": { value: '{typography.text-big.line-height}' },
-                "letter-spacing": { value: '{typography.text-big.letter-spacing}' },
-                "font-weight": { value: '{typography.text-big.font-weight}' },
-                "font-family": { value: '{typography.text-big.font-family}' },
-                "text-transform": { value: '{typography.text-big.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-big.font-feature-settings}' }
+                'font-size': { value: '{typography.text-big.font-size}' },
+                'line-height': { value: '{typography.text-big.line-height}' },
+                'letter-spacing': { value: '{typography.text-big.letter-spacing}' },
+                'font-weight': { value: '{typography.text-big.font-weight}' },
+                'font-family': { value: '{typography.text-big.font-family}' },
+                'text-transform': { value: '{typography.text-big.text-transform}' },
+                'font-feature-settings': { value: '{typography.text-big.font-feature-settings}' }
             }
         }
     }

--- a/packages/design-tokens/web/components/list.json5
+++ b/packages/design-tokens/web/components/list.json5
@@ -3,12 +3,12 @@
         size: {
             container: {
                 padding: {
-                    left: { value: '{size.m}'},
+                    left: { value: '{size.m}' },
                     right: { value: '{size.m}' },
                     vertical: { value: '{size.xs}' }
                 },
                 'content-gap': {
-                    horizontal: { value: '{size.s}'},
+                    horizontal: { value: '{size.s}' },
                     vertical: { value: '{size.3xs}' }
                 },
                 'focus-outline': {
@@ -22,14 +22,14 @@
             },
             header: {
                 padding: {
-                    top: { value: '{size.s}'},
+                    top: { value: '{size.s}' },
                     bottom: { value: '{size.xxs}' },
                     horizontal: { value: '{size.m}' }
                 }
             },
             subheading: {
                 padding: {
-                    top: { value: '{size.m}'},
+                    top: { value: '{size.m}' },
                     bottom: { value: '{size.xxs}' },
                     horizontal: { value: '{size.m}' }
                 }
@@ -37,46 +37,46 @@
         },
         font: {
             text: {
-                "font-size": { value: '{typography.text-normal.font-size}' },
-                "line-height": { value: '{typography.text-normal.line-height}' },
-                "letter-spacing": { value: '{typography.text-normal.letter-spacing}' },
-                "font-weight": { value: '{typography.text-normal.font-weight}' },
-                "font-family": { value: '{typography.text-normal.font-family}' },
-                "text-transform": { value: '{typography.text-normal.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-normal.font-feature-settings}' }
+                'font-size': { value: '{typography.text-normal.font-size}' },
+                'line-height': { value: '{typography.text-normal.line-height}' },
+                'letter-spacing': { value: '{typography.text-normal.letter-spacing}' },
+                'font-weight': { value: '{typography.text-normal.font-weight}' },
+                'font-family': { value: '{typography.text-normal.font-family}' },
+                'text-transform': { value: '{typography.text-normal.text-transform}' },
+                'font-feature-settings': { value: '{typography.text-normal.font-feature-settings}' }
             },
             caption: {
-                "font-size": { value: '{typography.text-compact.font-size}' },
-                "line-height": { value: '{typography.text-compact.line-height}' },
-                "letter-spacing": { value: '{typography.text-compact.letter-spacing}' },
-                "font-weight": { value: '{typography.text-compact.font-weight}' },
-                "font-family": { value: '{typography.text-compact.font-family}' },
-                "text-transform": { value: '{typography.text-compact.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-compact.font-feature-settings}' }
+                'font-size': { value: '{typography.text-compact.font-size}' },
+                'line-height': { value: '{typography.text-compact.line-height}' },
+                'letter-spacing': { value: '{typography.text-compact.letter-spacing}' },
+                'font-weight': { value: '{typography.text-compact.font-weight}' },
+                'font-family': { value: '{typography.text-compact.font-family}' },
+                'text-transform': { value: '{typography.text-compact.text-transform}' },
+                'font-feature-settings': { value: '{typography.text-compact.font-feature-settings}' }
             },
             header: {
-                "font-size": { value: '{typography.text-big-strong.font-size}' },
-                "line-height": { value: '{typography.text-big-strong.line-height}' },
-                "letter-spacing": { value: '{typography.text-big-strong.letter-spacing}' },
-                "font-weight": { value: '{typography.text-big-strong.font-weight}' },
-                "font-family": { value: '{typography.text-big-strong.font-family}' },
-                "text-transform": { value: '{typography.text-big-strong.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-big-strong.font-feature-settings}' }
+                'font-size': { value: '{typography.text-big-strong.font-size}' },
+                'line-height': { value: '{typography.text-big-strong.line-height}' },
+                'letter-spacing': { value: '{typography.text-big-strong.letter-spacing}' },
+                'font-weight': { value: '{typography.text-big-strong.font-weight}' },
+                'font-family': { value: '{typography.text-big-strong.font-family}' },
+                'text-transform': { value: '{typography.text-big-strong.text-transform}' },
+                'font-feature-settings': { value: '{typography.text-big-strong.font-feature-settings}' }
             },
             subheading: {
-                "font-size": { value: '{typography.caps-compact-strong.font-size}' },
-                "line-height": { value: '{typography.caps-compact-strong.line-height}' },
-                "letter-spacing": { value: '{typography.caps-compact-strong.letter-spacing}' },
-                "font-weight": { value: '{typography.caps-compact-strong.font-weight}' },
-                "font-family": { value: '{typography.caps-compact-strong.font-family}' },
-                "text-transform": { value: '{typography.caps-compact-strong.text-transform}' },
-                "font-feature-settings": { value: '{typography.caps-compact-strong.font-feature-settings}' }
+                'font-size': { value: '{typography.caps-compact-strong.font-size}' },
+                'line-height': { value: '{typography.caps-compact-strong.line-height}' },
+                'letter-spacing': { value: '{typography.caps-compact-strong.letter-spacing}' },
+                'font-weight': { value: '{typography.caps-compact-strong.font-weight}' },
+                'font-family': { value: '{typography.caps-compact-strong.font-family}' },
+                'text-transform': { value: '{typography.caps-compact-strong.text-transform}' },
+                'font-feature-settings': { value: '{typography.caps-compact-strong.font-feature-settings}' }
             }
         },
         light: {
             default: {
                 container: {
-                    background: { value: 'transparent'},
+                    background: { value: 'transparent' }
                 },
                 text: {
                     color: { value: '{light.foreground.contrast}' }
@@ -94,7 +94,7 @@
             states: {
                 hover: {
                     container: {
-                        background: { value: '{light.states.background.transparent-hover}'},
+                        background: { value: '{light.states.background.transparent-hover}' }
                     },
                     text: {
                         color: { value: '{light.foreground.contrast}' }
@@ -108,7 +108,7 @@
                 },
                 selected: {
                     container: {
-                        background: { value: '{light.background.theme-fade}'},
+                        background: { value: '{light.background.theme-less}' }
                     },
                     text: {
                         color: { value: '{light.foreground.contrast}' }
@@ -122,7 +122,7 @@
                 },
                 'selected-hover': {
                     container: {
-                        background: { value: '{light.states.background.theme-fade-hover}'},
+                        background: { value: '{light.states.background.theme-less-hover}' }
                     },
                     text: {
                         color: { value: '{light.foreground.contrast}' }
@@ -136,12 +136,12 @@
                 },
                 focused: {
                     'focus-outline': {
-                        color: { value: '{light.states.line.focus-theme}'}
+                        color: { value: '{light.states.line.focus-theme}' }
                     }
                 },
                 disabled: {
                     container: {
-                        background: { value: 'transparent'},
+                        background: { value: 'transparent' }
                     },
                     text: {
                         color: { value: '{light.states.foreground.disabled}' }
@@ -161,7 +161,7 @@
         dark: {
             default: {
                 container: {
-                    background: { value: 'transparent'},
+                    background: { value: 'transparent' }
                 },
                 text: {
                     color: { value: '{dark.foreground.contrast}' }
@@ -179,7 +179,7 @@
             states: {
                 hover: {
                     container: {
-                        background: { value: '{dark.states.background.transparent-hover}'},
+                        background: { value: '{dark.states.background.transparent-hover}' }
                     },
                     text: {
                         color: { value: '{dark.foreground.contrast}' }
@@ -193,7 +193,7 @@
                 },
                 selected: {
                     container: {
-                        background: { value: '{dark.background.theme-fade}'},
+                        background: { value: '{dark.background.theme-less}' }
                     },
                     text: {
                         color: { value: '{dark.foreground.contrast}' }
@@ -207,7 +207,7 @@
                 },
                 'selected-hover': {
                     container: {
-                        background: { value: '{dark.states.background.theme-fade-hover}'},
+                        background: { value: '{dark.states.background.theme-less-hover}' }
                     },
                     text: {
                         color: { value: '{dark.foreground.contrast}' }
@@ -221,12 +221,12 @@
                 },
                 focused: {
                     'focus-outline': {
-                        color: { value: '{dark.states.line.focus-theme}'}
+                        color: { value: '{dark.states.line.focus-theme}' }
                     }
                 },
                 disabled: {
                     container: {
-                        background: { value: 'transparent'},
+                        background: { value: 'transparent' }
                     },
                     text: {
                         color: { value: '{dark.states.foreground.disabled}' }

--- a/packages/design-tokens/web/components/tree.json5
+++ b/packages/design-tokens/web/components/tree.json5
@@ -202,7 +202,7 @@
                 },
                 selected: {
                     container: {
-                        background: { value: '{dark.background.theme-fade}' }
+                        background: { value: '{dark.background.theme-less}' }
                     },
                     text: {
                         color: { value: '{dark.foreground.contrast}' }
@@ -222,7 +222,7 @@
                 },
                 'selected-hover': {
                     container: {
-                        background: { value: '{dark.states.background.theme-fade-hover}' }
+                        background: { value: '{dark.states.background.theme-less-hover}' }
                     },
                     text: {
                         color: { value: '{dark.foreground.contrast}' }

--- a/packages/design-tokens/web/components/tree.json5
+++ b/packages/design-tokens/web/components/tree.json5
@@ -2,15 +2,15 @@
     tree: {
         size: {
             // отступ для уровней вложенностей (+24px на каждом уровне)
-            'indent-level': { value: '{size.xxl}'},
+            'indent-level': { value: '{size.xxl}' },
 
             container: {
                 padding: {
                     right: { value: '{size.s}' },
-                    vertical: { value: '{size.xxs}' },
+                    vertical: { value: '{size.xxs}' }
                 },
                 'content-gap': {
-                    horizontal: { value: '{size.s}'},
+                    horizontal: { value: '{size.s}' },
                     // задает отступ между text и caption
                     vertical: { value: '0px' }
                 },
@@ -26,28 +26,28 @@
         },
         font: {
             text: {
-                "font-size": { value: '{typography.text-normal.font-size}' },
-                "line-height": { value: '{typography.text-normal.line-height}' },
-                "letter-spacing": { value: '{typography.text-normal.letter-spacing}' },
-                "font-weight": { value: '{typography.text-normal.font-weight}' },
-                "font-family": { value: '{typography.text-normal.font-family}' },
-                "text-transform": { value: '{typography.text-normal.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-normal.font-feature-settings}' }
+                'font-size': { value: '{typography.text-normal.font-size}' },
+                'line-height': { value: '{typography.text-normal.line-height}' },
+                'letter-spacing': { value: '{typography.text-normal.letter-spacing}' },
+                'font-weight': { value: '{typography.text-normal.font-weight}' },
+                'font-family': { value: '{typography.text-normal.font-family}' },
+                'text-transform': { value: '{typography.text-normal.text-transform}' },
+                'font-feature-settings': { value: '{typography.text-normal.font-feature-settings}' }
             },
             caption: {
-                "font-size": { value: '{typography.text-compact.font-size}' },
-                "line-height": { value: '{typography.text-compact.line-height}' },
-                "letter-spacing": { value: '{typography.text-compact.letter-spacing}' },
-                "font-weight": { value: '{typography.text-compact.font-weight}' },
-                "font-family": { value: '{typography.text-compact.font-family}' },
-                "text-transform": { value: '{typography.text-compact.text-transform}' },
-                "font-feature-settings": { value: '{typography.text-compact.font-feature-settings}' }
+                'font-size': { value: '{typography.text-compact.font-size}' },
+                'line-height': { value: '{typography.text-compact.line-height}' },
+                'letter-spacing': { value: '{typography.text-compact.letter-spacing}' },
+                'font-weight': { value: '{typography.text-compact.font-weight}' },
+                'font-family': { value: '{typography.text-compact.font-family}' },
+                'text-transform': { value: '{typography.text-compact.text-transform}' },
+                'font-feature-settings': { value: '{typography.text-compact.font-feature-settings}' }
             }
         },
         light: {
             default: {
                 container: {
-                    background: { value: 'transparent'},
+                    background: { value: 'transparent' }
                 },
                 text: {
                     color: { value: '{light.foreground.contrast}' }
@@ -56,7 +56,7 @@
                     color: { value: '{light.icon.contrast}' }
                 },
                 'tree-toggle': {
-                     color: { value: '{light.icon.contrast-fade}' }
+                    color: { value: '{light.icon.contrast-fade}' }
                 },
                 'action-button': {
                     color: { value: '{light.icon.contrast-fade}' }
@@ -68,7 +68,7 @@
             states: {
                 hover: {
                     container: {
-                        background: { value: '{light.states.background.transparent-hover}'},
+                        background: { value: '{light.states.background.transparent-hover}' }
                     },
                     text: {
                         color: { value: '{light.foreground.contrast}' }
@@ -88,12 +88,12 @@
                 },
                 focused: {
                     'focus-outline': {
-                        color: { value: '{light.states.line.focus-theme}'}
+                        color: { value: '{light.states.line.focus-theme}' }
                     }
                 },
                 selected: {
                     container: {
-                        background: { value: '{light.background.theme-fade}'},
+                        background: { value: '{light.background.theme-less}' }
                     },
                     text: {
                         color: { value: '{light.foreground.contrast}' }
@@ -113,7 +113,7 @@
                 },
                 'selected-hover': {
                     container: {
-                        background: { value: '{light.states.background.theme-fade-hover}'},
+                        background: { value: '{light.states.background.theme-less-hover}' }
                     },
                     text: {
                         color: { value: '{light.foreground.contrast}' }
@@ -133,7 +133,7 @@
                 },
                 disabled: {
                     container: {
-                        background: { value: 'transparent'},
+                        background: { value: 'transparent' }
                     },
                     text: {
                         color: { value: '{light.states.foreground.disabled}' }
@@ -156,7 +156,7 @@
         dark: {
             default: {
                 container: {
-                    background: { value: 'transparent'},
+                    background: { value: 'transparent' }
                 },
                 text: {
                     color: { value: '{dark.foreground.contrast}' }
@@ -165,7 +165,7 @@
                     color: { value: '{dark.icon.contrast}' }
                 },
                 'tree-toggle': {
-                     color: { value: '{dark.icon.contrast-fade}' }
+                    color: { value: '{dark.icon.contrast-fade}' }
                 },
                 'action-button': {
                     color: { value: '{dark.icon.contrast-fade}' }
@@ -177,7 +177,7 @@
             states: {
                 hover: {
                     container: {
-                        background: { value: '{dark.states.background.transparent-hover}'},
+                        background: { value: '{dark.states.background.transparent-hover}' }
                     },
                     text: {
                         color: { value: '{dark.foreground.contrast}' }
@@ -197,12 +197,12 @@
                 },
                 focused: {
                     'focus-outline': {
-                        color: { value: '{dark.states.line.focus-theme}'}
+                        color: { value: '{dark.states.line.focus-theme}' }
                     }
                 },
                 selected: {
                     container: {
-                        background: { value: '{dark.background.theme-fade}'},
+                        background: { value: '{dark.background.theme-fade}' }
                     },
                     text: {
                         color: { value: '{dark.foreground.contrast}' }
@@ -222,7 +222,7 @@
                 },
                 'selected-hover': {
                     container: {
-                        background: { value: '{dark.states.background.theme-fade-hover}'},
+                        background: { value: '{dark.states.background.theme-fade-hover}' }
                     },
                     text: {
                         color: { value: '{dark.foreground.contrast}' }
@@ -242,7 +242,7 @@
                 },
                 disabled: {
                     container: {
-                        background: { value: 'transparent'},
+                        background: { value: 'transparent' }
                     },
                     text: {
                         color: { value: '{dark.states.foreground.disabled}' }

--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -56,6 +56,7 @@
             //  THEME
             theme: { value: '{light.theme.default.value}' },
             'theme-fade': { value: '{light.theme.palette.value.85}' },
+            'theme-less': { value: '{light.theme.palette.value.94}' },
             //  CONTRAST
             contrast: { value: '{light.contrast.palette.value.25}' },
             'contrast-fade': { value: '{light.contrast.palette.value.92}' },
@@ -143,9 +144,10 @@
             //  THEME
             theme: { value: '{light.theme.default}' },
             'theme-fade': { value: '{light.theme.palette.value.65}' },
+            'theme-less': { value: '{light.theme.palette.value.85}' },
             //  CONTRAST
             contrast: { value: '{light.contrast.palette.value.15}' },
-            'contrast-fade': { value: '{light.contrast.palette.value.70}' },
+            'contrast-fade': { value: '{light.contrast.palette.value.80}' },
             'contrast-less': { value: '{light.contrast.palette.value."6-A12"}' },
             //  ERROR
             error: { value: '{light.error.palette.value.45}' },
@@ -162,7 +164,7 @@
         shadow: {
             outline: { value: '{light.contrast.palette.value."6-A3"}' },
             key: { value: '{light.contrast.palette.value."6-A6"}' },
-            ambient: { value: '{light.contrast.palette.value."6-A12"}' },
+            ambient: { value: '{light.contrast.palette.value."6-A12"}' }
         },
         states: {
             background: {
@@ -171,6 +173,8 @@
                 'theme-active': { value: '{light.theme.palette.value.39}' },
                 'theme-fade-hover': { value: '{light.theme.palette.value.91}' },
                 'theme-fade-active': { value: '{light.theme.palette.value.88}' },
+                'theme-less-hover': { value: '{light.theme.palette.value.90}' },
+                'theme-less-active': { value: '{light.theme.palette.value.94}' },
                 //  CONTRAST
                 'contrast-hover': { value: '{light.contrast.palette.value.20}' },
                 'contrast-active': { value: '{light.contrast.palette.value.15}' },
@@ -304,6 +308,7 @@
             //  THEME
             theme: { value: '{dark.theme.default.value}' },
             'theme-fade': { value: '{dark.theme.palette.value.20}' },
+            'theme-less': { value: '{dark.theme.palette.value.18}' },
             //  CONTRAST
             bg: { value: '{dark.contrast.palette.value.12}' },
             'bg-secondary': { value: '{dark.contrast.palette.value.16}' },
@@ -395,6 +400,7 @@
             //  THEME
             theme: { value: '{dark.theme.palette.value.65}' },
             'theme-fade': { value: '{dark.theme.palette.value.30}' },
+            'theme-less': { value: '{dark.theme.palette.value.27}' },
             //  CONTRAST
             contrast: { value: '{dark.contrast.palette.value.100}' },
             'contrast-fade': { value: '{dark.contrast.palette.value.30}' },
@@ -414,7 +420,7 @@
         shadow: {
             outline: { value: '{dark.contrast.palette.value."85-S100-A15"}' },
             key: { value: 'transparent' },
-            ambient: { value: 'transparent' },
+            ambient: { value: 'transparent' }
         },
         states: {
             background: {
@@ -423,6 +429,8 @@
                 'theme-active': { value: '{dark.theme.palette.value.39}' },
                 'theme-fade-hover': { value: '{dark.theme.palette.value.18}' },
                 'theme-fade-active': { value: '{dark.theme.palette.value.21}' },
+                'theme-less-hover': { value: '{dark.theme.palette.value.15}' },
+                'theme-less-active': { value: '{dark.theme.palette.value.18}' },
                 //  CONTRAST
                 'contrast-hover': { value: '{dark.contrast.palette.value.80}' },
                 'contrast-active': { value: '{dark.contrast.palette.value.55}' },


### PR DESCRIPTION
## Updates

| token                               | Light          | Dark           |
| ----------------------------------- | -------------- | -------------- |
| background/theme-fade               | theme-85       | theme-20       |
| background/theme-less               | + **theme-94** | + **theme-18** |
| states-background/theme-less-hover  | + **theme-90** | + **theme-15** |
| states-background/theme-less-active | + **theme-94** | + **theme-18** |
| states-background/theme-fade-hover  | theme-91       | theme-18       |
| states-background/theme-fade-active | theme-88       | theme-21       |
| lines/theme-fade                    | theme-65       | theme-30       |
| lines/theme-less                    | + **theme-85** | + **theme-27** |

Fixed cases with high contrast fields:

| token               | Light                   |
| ------------------- | ----------------------- |
| lines/contrast-fade | theme-70 → **theme-80** |
