### PR TITLE
feat(colors): delete deprecated tokens, remove it from components

### DIFF
--- a/packages/design-tokens/web/components/checkbox.json5
+++ b/packages/design-tokens/web/components/checkbox.json5
@@ -4,7 +4,7 @@
             theme: {
                 default: {
                     border: { value: '{light.line.contrast-fade}' },
-                    color: { value: '{light.neutral.white}' },
+                    color: { value: '{light.icon.white}' },
                     text: { value: '{light.foreground.contrast}' },
                     background: { value: '{light.background.bg}' },
                     caption: { value: '{light.foreground.contrast-secondary}' }
@@ -45,7 +45,7 @@
             error: {
                 default: {
                     border: { value: '{light.line.error}' },
-                    color: { value: '{light.neutral.white}' },
+                    color: { value: '{light.icon.white}' },
                     text: { value: '{light.foreground.contrast}' },
                     background: { value: '{light.states.background.error-less}' },
                     caption: { value: '{light.foreground.contrast-secondary}' }
@@ -88,7 +88,7 @@
             theme: {
                 default: {
                     border: { value: '{dark.line.contrast-fade}' },
-                    color: { value: '{dark.neutral.white}' },
+                    color: { value: '{dark.icon.white}' },
                     text: { value: '{dark.foreground.contrast}' },
                     background: { value: '{dark.background.bg}' },
                     caption: { value: '{dark.foreground.contrast-secondary}' }
@@ -129,7 +129,7 @@
             error: {
                 default: {
                     border: { value: '{dark.line.error}' },
-                    color: { value: '{dark.neutral.white}' },
+                    color: { value: '{dark.icon.white}' },
                     text: { value: '{dark.foreground.contrast}' },
                     background: { value: '{dark.states.background.error-less}' },
                     caption: { value: '{dark.foreground.contrast-secondary}' }

--- a/packages/design-tokens/web/components/dl.json5
+++ b/packages/design-tokens/web/components/dl.json5
@@ -40,7 +40,7 @@
         },
         light: {
             term: {
-                color: { value: '{light.foreground.text-less-contrast}'}
+                color: { value: '{light.foreground.contrast-secondary}'}
             },
             description: {
                 color: { value: '{light.foreground.contrast}'}
@@ -48,7 +48,7 @@
         },
         dark: {
             term: {
-                color: { value: '{dark.foreground.text-less-contrast}'}
+                color: { value: '{dark.foreground.contrast-secondary}'}
             },
             description: {
                 color: { value: '{dark.foreground.contrast}'}

--- a/packages/design-tokens/web/components/markdown.json5
+++ b/packages/design-tokens/web/components/markdown.json5
@@ -200,13 +200,13 @@
             light: {
                 text: { value: '{light.foreground.contrast}' },
                 line: { value: '{light.line.contrast-less}' },
-                background: { value: 'transparent' },
+                background: { value: '{light.background.contrast-fade}' },
                 border: { value: 'transparent' }
             },
             dark: {
                 text: { value: '{dark.foreground.contrast}' },
                 line: { value: '{dark.line.contrast-less}' },
-                background: { value: 'transparent' },
+                background: { value: '{dark.background.contrast-fade}' },
                 border: { value: 'transparent' }
             },
             size: {

--- a/packages/design-tokens/web/components/markdown.json5
+++ b/packages/design-tokens/web/components/markdown.json5
@@ -10,7 +10,7 @@
             size: {
                 'max-width': { value: '{markdown.size.max-width}'},
                 'margin-top': { value: '0' },
-                'margin-bottom': { value: '{size.m}' },
+                'margin-bottom': { value: '{size.l}' },
             },
             font: {
                 default: {
@@ -33,7 +33,7 @@
             },
             size: {
                 'max-width': { value: '{markdown.size.max-width}'},
-                'margin-top': { value: '{size.3xl}' },
+                'margin-top': { value: '{size.xxl}' },
                 'margin-bottom': { value: '{size.m}' },
             },
             font: {
@@ -57,7 +57,7 @@
             },
             size: {
                 'max-width': { value: '{markdown.size.max-width}'},
-                'margin-top': { value: '28px' },
+                'margin-top': { value: '{size.xxl}' },
                 'margin-bottom': { value: '{size.m}' },
             },
             font: {
@@ -106,7 +106,7 @@
             size: {
                 'max-width': { value: '{markdown.size.max-width}'},
                 'margin-top': { value: '{size.xxl}' },
-                'margin-bottom': { value: '{size.m}' },
+                'margin-bottom': { value: '{size.s}' },
             },
             font: {
                 default: {
@@ -130,7 +130,7 @@
             size: {
                 'max-width': { value: '{markdown.size.max-width}'},
                 'margin-top': { value: '{size.xxl}' },
-                'margin-bottom': { value: '{size.m}' },
+                'margin-bottom': { value: '{size.s}' },
             },
             font: {
                 default: {
@@ -182,7 +182,7 @@
                 'margin-top-after-paragraph': { value: '-{size.s}' },
                 'ol-number-padding-right': { value: '{size.xxs}' },
                 'ul-padding': { value: '0 0 0 {size.xxl}' },
-                'item-margin-bottom': { value: '{size.s}' }
+                'item-margin-bottom': { value: '{size.xxs}' }
             },
             font: {
                 default: {
@@ -199,21 +199,21 @@
         blockquote: {
             light: {
                 text: { value: '{light.foreground.contrast}' },
-                line: { value: '{light.foreground.border}' },
-                background: { value: '{light.background.contrast-fade}' },
+                line: { value: '{light.line.contrast-less}' },
+                background: { value: 'transparent' },
                 border: { value: 'transparent' }
             },
             dark: {
                 text: { value: '{dark.foreground.contrast}' },
-                line: { value: '{dark.foreground.border}' },
-                background: { value: '{dark.background.contrast-fade}' },
+                line: { value: '{dark.line.contrast-less}' },
+                background: { value: 'transparent' },
                 border: { value: 'transparent' }
             },
             size: {
                 'max-width': { value: '{markdown.size.max-width}'},
-                'margin-top': { value: '{size.xl}' },
-                'margin-bottom': { value: '{size.xxl}' },
-                'padding': { value: '{size.m} {size.l}' },
+                'margin-top': { value: '{size.m}' },
+                'margin-bottom': { value: '{size.m}' },
+                'padding': { value: '{size.3xs} {size.m}' },
                 'line-width': { value: '{size.xxs}' },
                 'border-radius': { value: '0' },
                 'border-width': { value: '0' },
@@ -233,20 +233,20 @@
         code: {
             light: {
                 text: { value: '{light.foreground.contrast}' },
-                background: { value: '{light.background.background-less-contrast}' },
+                background: { value: '{light.background.contrast-fade}' },
                 border: { value: '{light.line.contrast-less}' }
             },
             dark: {
                 text: { value: '{dark.foreground.contrast}' },
-                background: { value: '{dark.background.background-less-contrast}' },
+                background: { value: '{dark.background.contrast-fade}' },
                 border: { value: '{dark.line.contrast-less}' }
             },
             size: {
                 'max-width': { value: '{markdown.size.max-width}'},
-                'multiline-margin-top': { value: '{size.s}' },
+                'multiline-margin-top': { value: '{size.m}' },
                 'multiline-margin-bottom': { value: '{size.xxl}' },
                 'inline-padding': { value: '0 {size.xxs}' },
-                'multiline-padding': { value: '14px {size.xl}' },
+                'multiline-padding': { value: '{size.m} {size.l}' },
                 'border-radius': { value: '{size.border-radius}' },
                 'border-width': { value: '{size.border-width}' },
             },
@@ -322,15 +322,15 @@
         },
         image: {
             light: {
-                'caption-text': { value: '{light.foreground.text-less-contrast}' }
+                'caption-text': { value: '{light.foreground.contrast-secondary}' }
             },
             dark: {
-                'caption-text': { value: '{dark.foreground.text-less-contrast}' }
+                'caption-text': { value: '{dark.foreground.contrast-secondary}' }
             },
             size: {
                 'max-width': { value: '{markdown.size.max-width}'},
-                'margin-top': { value: '{size.s}' },
-                'margin-bottom': { value: '{size.s}' },
+                'margin-top': { value: '{size.m}' },
+                'margin-bottom': { value: '{size.m}' },
 
                 'caption-margin-top': { value: '-{size.s}' },
                 'caption-margin-bottom': { value: '{size.xxl}' },
@@ -356,24 +356,24 @@
             },
             size: {
                 'width': { value: '1px'},
-                'margin-vertical': { value: '{size.l}' },
+                'margin-vertical': { value: '{size.xxl}' },
             },
         },
         table: {
             light: {
-                header: { value: '{light.foreground.text-less-contrast}' },
+                header: { value: '{light.foreground.contrast-secondary}' },
                 body: { value: '{light.foreground.contrast}' },
                 border: { value: '{light.line.contrast-less}' }
             },
             dark: {
-                header: { value: '{dark.foreground.text-less-contrast}' },
+                header: { value: '{dark.foreground.contrast-secondary}' },
                 body: { value: '{dark.foreground.contrast}' },
                 border: { value: '{dark.line.contrast-less}' }
             },
             size: {
                 'border-width': { value: '{size.border-width}'},
                 'padding': { value: '{size.s}' },
-                'margin-bottom': { value: '{size.l}' }
+                'margin-bottom': { value: '{size.m}' }
             },
             font: {
                 header: {

--- a/packages/design-tokens/web/components/popup.json5
+++ b/packages/design-tokens/web/components/popup.json5
@@ -4,13 +4,13 @@
             shadow: { value: '{shadow.light.popup}' },
             border: { value: 'transparent' },
             background: { value: '{light.background.card}' },
-            'footer-background': { value: '{light.background.background-disabled}'}
+            'footer-background': { value: '{light.background.card}'}
         },
         dark: {
             shadow: { value: '{shadow.dark.popup}' },
             border: { value: 'transparent' },
             background: { value: '{dark.background.card}' },
-            'footer-background': { value: 'transparent' }
+            'footer-background': { value: '{dark.background.card}'}
         }
     }
 }

--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -151,7 +151,7 @@
                 'error-active': { value: '{light.error.palette.value."51-S69"}' },
                 'error-fade-hover': { value: '{light.error.palette.value.92}' },
                 'error-fade-active': { value: '{light.error.palette.value.88}' },
-                'error-less': { value: '{light.error.palette.value.99}' }, // TODO: будет удалено, после удаления из компонентов
+                'error-less': { value: '{light.error.palette.value.99}' },
                 //  SUCCESS
                 //  WARNING
                 'warning-fade-hover': { value: '{light.warning.palette.value.87}' },
@@ -203,7 +203,6 @@
                 // ERROR
                 'focus-error': { value: '{light.error.palette.value.45}' }
             },
-            // TODO: нижнее будет удалено, после удаления из компонентов ↓
             'disabled-opacity': { value: 0.32 }
         },
     },
@@ -363,7 +362,7 @@
                 'error-active': { value: '{dark.error.palette.value.39}' },
                 'error-fade-hover': { value: '{dark.error.palette.value.13}' },
                 'error-fade-active': { value: '{dark.error.palette.value.16}' },
-                'error-less': { value: '{dark.error.palette.value.6}' }, // TODO: будет удалено, после удаления из компонентов
+                'error-less': { value: '{dark.error.palette.value.6}' },
                 //  WARNING
                 'warning-fade-hover': { value: '{dark.warning.palette.value.13}' },
                 'warning-fade-active': { value: '{dark.warning.palette.value.16}' }

--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -20,11 +20,6 @@
             default: { value: '{palette.grey.50}' },
             palette: { value: '{palette.grey}' }
         },
-        // TODO: neuntral убрать из компонентов
-        neutral: {
-            white: { value: '{palette.white.default}' },
-            black: { value: '{palette.black.default}' }
-        },
         white: {
             default: { value: '{palette.white.default}' },
             palette: { value: '{palette.white}' }
@@ -33,20 +28,10 @@
             default: { value: '{palette.black.default}' },
             palette: { value: '{palette.black}' }
         },
-        brand: {
-            default: { value: '{palette.red.50}' },
-            palette: { value: '{palette.red}' }
-        },
         purple: {
             default: { value: '{palette.purple.50}' },
             palette: { value: '{palette.purple}' }
         },
-        // TODO: УТОЧНИТЬ: нудно ли info убрать из компонентов? В темной теме был комментарий с info и secondary
-        info: {
-            default: { value: '{palette.cyan.50}' },
-            palette: { value: '{palette.cyan}' }
-        },
-        // будет удалено, после удаления из компонентов ↑
         background: {
             bg: { value: '{light.white.default}' },
             'bg-secondary': { value: '{light.contrast.palette.value.95}' },
@@ -70,19 +55,10 @@
             //  WARNING
             warning: { value: '{light.warning.palette.value.50}' },
             'warning-fade': { value: '{light.warning.palette.value.85}' },
-            //  VISITED
             //  OTHER
             transparent: { value: 'transparent' },
-            // TODO: убрать все нижние параметры из компонентов
-            background: { value: '{light.white.default}' },
-            'background-disabled': { value: '{light.contrast.palette.value.95}' },
-            'background-less-contrast': { value: '{light.contrast.palette.value.95}' },
-            'background-under': { value: '{light.contrast.palette.value.95}' },
             overlay: { value: '{light.contrast.palette.value."20-A32"}' },
             'overlay-inverse': { value: '{light.contrast.palette.value."99-A88"}' },
-            'overlay-hover': { value: '{light.black.palette.value."default-A8"}' },
-            'overlay-active': { value: '{light.black.palette.value."default-A16"}' },
-            'overlay-disabled': { value: '{light.white.palette.value."default-A64"}' }
         },
         foreground: {
             //  WHITE
@@ -100,26 +76,16 @@
             error: { value: '{light.error.palette.value.40}' },
             'error-secondary': { value: '{light.error.palette.value.50}' },
             'error-tertiary': { value: '{light.error.palette.value.70}' },
-            'error-less': { value: '{light.error.palette.value.90}' }, // TODO: будет удалено, после удаления из компонентов
+            'error-less': { value: '{light.error.palette.value.90}' },
             //  SUCCESS
             success: { value: '{light.success.palette.value.30}' },
-            'success-less': { value: '{light.success.palette.value.90}' }, // TODO: будет удалено, после удаления из компонентов
+            'success-less': { value: '{light.success.palette.value.90}' },
             'success-secondary': { value: '{light.success.palette.value.45}' },
             //  WARNING
             warning: { value: '{light.warning.palette.value.33}' },
             'warning-secondary': { value: '{light.warning.palette.value.45}' },
             //  VISITED
             visited: { value: '{light.purple.palette.value.45}' },
-            //  OTHER
-            // TODO: убрать все нижние параметры из компонентов
-            text: { value: '{light.contrast.palette.value.15}' },
-            'text-less-contrast': { value: '{light.contrast.palette.value.50}' },
-            'text-disabled': { value: '{light.contrast.palette.value.70}' },
-            'text-error': { value: '{light.error.palette.value.50}' },
-            'text-success': { value: '{light.success.palette.value.44}' },
-            divider: { value: '{light.line.contrast-less}' },
-            border: { value: '{light.line.contrast-fade}' },
-            icon: { value: '{light.icon.contrast-fade}' }
         },
         icon: {
             //  WHITE
@@ -195,9 +161,6 @@
                 disabled: { value: '{light.contrast.palette.value."50-A16"}' },
                 'transparent-hover': { value: '{light.contrast.palette.value."50-A8"}' },
                 'transparent-active': { value: '{light.contrast.palette.value."50-A16"}' },
-                // TODO: нижнее будет удалено, после удаления из компонентов
-                'ghost-hover': { value: 'rgba(106, 115, 150, 0.08)' },
-                'ghost-active': { value: 'rgba(106, 115, 150, 0.16)' }
             },
             foreground: {
                 //  THEME
@@ -241,15 +204,8 @@
                 'focus-error': { value: '{light.error.palette.value.45}' }
             },
             // TODO: нижнее будет удалено, после удаления из компонентов ↓
-            'focused-color': { value: '{light.theme.palette.value.50}' },
-            'focused-color-error': { value: '{light.error.palette.value.50}' },
-            'selected-color': { value: '{light.theme.palette.value.95}' },
-            'pressed-shadow': { value: 'inset 0 1px 2px 0 {light.black.palette.value."default-A20"}' },
             'disabled-opacity': { value: 0.32 }
         },
-        others: {
-            brand: { value: '{light.brand.default}' }
-        }
     },
     // DARK THEME
     dark: {
@@ -273,11 +229,6 @@
             default: { value: '{palette.grey.50}' },
             palette: { value: '{palette.grey}' }
         },
-        // TODO: neutral из компонентов
-        neutral: {
-            white: { value: '{palette.white.default}' },
-            black: { value: '{palette.black.default}' }
-        },
         white: {
             default: { value: '{palette.white.default}' },
             palette: { value: '{palette.white}' }
@@ -286,23 +237,9 @@
             default: { value: '{palette.black.default}' },
             palette: { value: '{palette.black}' }
         },
-        brand: {
-            default: { value: '{palette.red.50}' },
-            palette: { value: '{palette.red}' }
-        },
         purple: {
             default: { value: '{palette.purple.50}' },
             palette: { value: '{palette.purple}' }
-        },
-        // TODO: secondary из компонентов
-        secondary: {
-            default: { value: '{palette.grey.50}' },
-            palette: { value: '{palette.grey}' }
-        },
-        // TODO: info из компонентов
-        info: {
-            default: { value: '{palette.cyan.50}' },
-            palette: { value: '{palette.cyan}' }
         },
         background: {
             //  THEME
@@ -329,16 +266,8 @@
             'warning-fade': { value: '{dark.warning.palette.value.14}' },
             //  OTHER
             transparent: { value: 'transparent' },
-            // TODO: убрать все нижние параметры из компонентов
-            background: { value: '{dark.white.default}' },
-            'background-disabled': { value: '{dark.contrast.palette.value.95}' },
-            'background-less-contrast': { value: '{dark.contrast.palette.value.95}' },
-            'background-under': { value: '{dark.contrast.palette.value.95}' },
-            overlay: { value: '{dark.contrast.palette.value."6-A64"}' },
-            'overlay-inverse': { value: '{dark.contrast.palette.value."12-A80"}' },
-            'overlay-hover': { value: 'rgba(black, 0.08)' },
-            'overlay-active': { value: 'rgba(black, 0.16)' },
-            'overlay-disabled': { value: 'rgba(white, 0.64)' }
+            overlay: { value: '{light.contrast.palette.value."6-A64"}' },
+            'overlay-inverse': { value: '{light.contrast.palette.value."12-A80"}' },
         },
         foreground: {
             //  WHITE
@@ -366,16 +295,6 @@
             'warning-secondary': { value: '{dark.warning.palette.value.40}' },
             //  VISITED
             visited: { value: '{dark.purple.palette.value.50}' },
-            //  OTHER
-            // TODO: убрать все нижние параметры из компонентов
-            text: { value: '{dark.contrast.palette.value.15}' },
-            'text-less-contrast': { value: '{dark.contrast.palette.value.50}' },
-            'text-disabled': { value: '{dark.contrast.palette.value.70}' },
-            'text-error': { value: '{dark.error.palette.value.50}' },
-            'text-success': { value: '{dark.success.palette.value.44}' },
-            divider: { value: '{dark.line.contrast-less}' },
-            border: { value: '{dark.line.contrast-fade}' },
-            icon: { value: '{dark.icon.contrast-fade}' }
         },
         icon: {
             //  WHITE
@@ -491,15 +410,7 @@
                 //  ERROR
                 'focus-error': { value: '{dark.error.palette.value.45}' }
             },
-            // TODO: будет удалено, после удаления из компонентов ↓
-            'focused-color': { value: '{dark.theme.palette.value.50}' },
-            'focused-color-error': { value: '{dark.error.palette.value.50}' },
-            'selected-color': { value: '{dark.theme.palette.value.95}' },
-            'pressed-shadow': { value: 'inset 0 1px 2px 0 rgba(black, 0.2)' },
             'disabled-opacity': { value: 0.32 }
-        },
-        others: {
-            brand: { value: '{dark.brand.default}' }
         }
     }
 }

--- a/packages/design-tokens/web/properties/typography.json5
+++ b/packages/design-tokens/web/properties/typography.json5
@@ -1,68 +1,5 @@
 {
     "typography": {
-        // После замены типографики в продуктах старые стили будут удалены
-        // display-1 заменить в продуктах на "display-big"
-        "display-1": {
-            "font-size": { value: '57px' },
-            "line-height": { value: '64px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '400' },
-            "font-family": { value: '{font.family.accent}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga"' }
-        },
-        // display-2 заменить в продуктах на "display-normal"
-        "display-2": {
-            "font-size": { value: '45px' },
-            "line-height": { value: '52px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '400' },
-            "font-family": { value: '{font.family.accent}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga"' }
-        },
-        // display-3 заменить в продуктах на "display-compact"
-        "display-3": {
-            "font-size": { value: '36px' },
-            "line-height": { value: '44px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '400' },
-            "font-family": { value: '{font.family.accent}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga"' }
-        },
-        // display-1-strong заменить в продуктах на "display-big-strong"
-        "display-1-strong": {
-            "font-size": { value: '57px' },
-            "line-height": { value: '64px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '700' },
-            "font-family": { value: '{font.family.accent}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga"' }
-        },
-        // display-2-strong заменить в продуктах на "display-normal-strong"
-        "display-2-strong": {
-            "deprecated": true,
-            "deprecated_comment": "replace with the \"blue\" color",
-            "font-size": { value: '45px' },
-            "line-height": { value: '52px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '700' },
-            "font-family": { value: '{font.family.accent}' },
-            "text-transform": { value: 'initial',  },
-            "font-feature-settings": { value: '"calt", "kern", "liga"' }
-        },
-        // display-3-strong заменить в продуктах на "display-compact-strong"
-        "display-3-strong": {
-            "font-size": { value: '36px' },
-            "line-height": { value: '44px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '700' },
-            "font-family": { value: '{font.family.accent}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga"' }
-        },
         "headline": {
             "font-size": { value: '28px' },
             "line-height": { value: '32px' },
@@ -90,167 +27,6 @@
             "text-transform": { value: 'initial' },
             "font-feature-settings": { value: '"calt", "kern", "liga"' }
         },
-        // body заменять на "text.big"
-        "body": {
-            "font-size": { value: '16px' },
-            "line-height": { value: '24px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
-        },
-        // body-tabular заменять на "tabular.big"
-        "body-tabular": {
-            "font-size": { value: '16px' },
-            "line-height": { value: '24px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "ss01", "ss04", "tnum"' }
-        },
-        // body-strong заменять на "text.big-strong"
-        "body-strong": {
-            "font-size": { value: '16px' },
-            "line-height": { value: '24px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '500' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
-        },
-        // body-caps заменять на "caps.big"
-        "body-caps": {
-            "font-size": { value: '16px' },
-            "line-height": { value: '24px' },
-            "letter-spacing": { value: '0.08em' },
-            "font-weight": { value: '400' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'uppercase' },
-            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
-        },
-        // body-mono заменять на "mono.big"
-        "body-mono": {
-            "font-size": { value: '16px' },
-            "line-height": { value: '24px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.mono}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: 'initial' }
-        },
-        // body-mono-strong заменять на "mono.big-strong"
-        "body-mono-strong": {
-            "font-size": { value: '16px' },
-            "line-height": { value: '24px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '700' },
-            "font-family": { value: '{font.family.mono}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: 'initial' }
-        },
-        // caption заменять на "text.normal"
-        "caption": {
-            "font-size": { value: '14px' },
-            "line-height": { value: '20px' },
-            "letter-spacing": { value: '-0.006em' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
-        },
-        // caption-tabular заменять на "tabular.normal"
-        "caption-tabular": {
-            "font-size": { value: '14px' },
-            "line-height": { value: '20px' },
-            "letter-spacing": { value: '-0.006em' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "ss01", "ss04", "tnum"' }
-        },
-        // caption-strong заменять на "text.normal-strong"
-        "caption-strong": {
-            "font-size": { value: '14px' },
-            "line-height": { value: '20px' },
-            "letter-spacing": { value: '-0.006em' },
-            "font-weight": { value: '500' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
-        },
-        // caption-caps заменять на "caps.normal"
-        "caption-caps": {
-            "font-size": { value: '14px' },
-            "line-height": { value: '20px' },
-            "letter-spacing": { value: '0.08em' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'uppercase' },
-            "font-feature-settings": { value: '"calt", "case", "kern", "liga", "ss01", "ss04"' }
-        },
-        // caption-mono заменять на "mono.normal"
-        "caption-mono": {
-            "font-size": { value: '14px' },
-            "line-height": { value: '20px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.mono}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: 'initial' }
-        },
-        // caption-mono-strong заменять на "mono.normal-strong"
-        "caption-mono-strong": {
-            "font-size": { value: '14px' },
-            "line-height": { value: '20px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '700' },
-            "font-family": { value: '{font.family.mono}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: 'initial' }
-        },
-        // extra-small-text заменять на "text.compact"
-        "extra-small-text": {
-            "font-size": { value: '12px' },
-            "line-height": { value: '16px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
-        },
-        // extra-small-text-strong заменять на "text.compact-strong"
-        "extra-small-text-strong": {
-            "font-size": { value: '12px' },
-            "line-height": { value: '16px' },
-            "letter-spacing": { value: 'normal' },
-            "font-weight": { value: '500' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: '"calt", "kern", "liga", "ss01", "ss04"' }
-        },
-        // extra-small-text-caps заменять на "caps.compact"
-        "extra-small-text-caps": {
-            "font-size": { value: '12px' },
-            "line-height": { value: '16px' },
-            "letter-spacing": { value: '1px' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.base}' },
-            "text-transform": { value: 'uppercase' },
-            "font-feature-settings": { value: '"calt", "case", "kern", "liga", "ss01", "ss04"' }
-        },
-        // extra-small-text-mono заменять на "mono.compact"
-        "extra-small-text-mono": {
-            "font-size": { value: '12px' },
-            "line-height": { value: '16px' },
-            "letter-spacing": { value: '0px' },
-            "font-weight": { value: 'normal' },
-            "font-family": { value: '{font.family.mono}' },
-            "text-transform": { value: 'initial' },
-            "font-feature-settings": { value: 'initial' }
-        },
-        // New typography
         "display-big": {
             "font-size": { value: '57px' },
             "line-height": { value: '64px' },
@@ -630,27 +406,27 @@
           }
     },
     'zh-CN': {
-        "body-strong": {
+        "text-normal-strong": {
             "font-weight": { value: 'normal' },
         },
-        "body-mono-strong": {
+        "mono-normal-strong": {
             "font-weight": { value: 'normal' },
         },
-        "caption-strong": {
+        "text-compact-strong": {
             "font-weight": { value: 'normal' },
         },
-        "caption-mono-strong": {
+        "mono-compact-strong": {
             "font-weight": { value: 'normal' },
         }
     },
     'fa-IR':{
-        "display-1": {
+        "display-big": {
             "font-family": { value: '{font.fa-IR.accent}' }
         },
-        "display-2": {
+        "display-normal": {
             "font-family": { value: '{font.fa-IR.accent}' }
         },
-        "display-3": {
+        "display-compact": {
             "font-family": { value: '{font.fa-IR.accent}' }
         },
         "title": {
@@ -659,38 +435,30 @@
         "subheading": {
             "font-family": { value: '{font.fa-IR.base}' }
         },
-        "body": {
+        "text-normal": {
             "font-family": { value: '{font.fa-IR.base}' }
         },
-        "body-tabular": {
+        "tabular-normal": {
             "font-family": { value: '{font.fa-IR.base}' }
         },
-        "body-strong": {
+        "text-normal-strong": {
             "font-family": { value: '{font.fa-IR.base}' }
         },
-        "body-caps": {
+        "caps-normal": {
             "font-family": { value: '{font.fa-IR.base}' }
         },
-        "caption": {
+        "text-compact": {
             "font-family": { value: '{font.fa-IR.base}' }
         },
-        "caption-tabular": {
+        "tabular-compact": {
             "font-family": { value: '{font.fa-IR.base}' }
         },
-        "caption-strong": {
+        "text-compact-strong": {
             "font-family": { value: '{font.fa-IR.base}' }
         },
-        "caption-caps": {
+        "caps-compact": {
             "font-family": { value: '{font.fa-IR.base}' }
         },
-        "small-text": {
-            "font-family": { value: '{font.fa-IR.base}' }
-        },
-        "extra-small-text": {
-            "font-family": { value: '{font.fa-IR.base}' }
-        },
-        "extra-small-text-caps": {
-            "font-family": { value: '{font.fa-IR.base}' }
-        }
+
     }
 }


### PR DESCRIPTION
Наверняка, это будет BREAKING CHANGE 

Удалил из кода устаревшие токены Мозаика и токены кубика, который в итоге самоустранились. Исправил использование по компонентам

Удалено куча стилей типогриафики из Мозаика
text, caption, display-1 и тд

Удалил палитры
info, neutral, brand

Удалил токены background и foreground из Мозаика

Добавил токены
background.overlay: 
background.overlay-inverse

Обновились значения токенов в компонентах. 
checkbox
dl
markdown (blockquote)
popup

Надо перепроверить в angular-components использование удаленных токенов и палитр
