### PR TITLE
fix(colors): sync states-line-disabled with figma (#DS-2874)

### DIFF
--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -236,7 +236,7 @@
                 focus: { value: '{light.theme.palette.value.50}' },
                 'focus-theme': { value: '{light.theme.palette.value.60}' },
                 // CONTRAST
-                disabled: { value: '{light.contrast.palette.value."15-A32"}' },
+                disabled: { value: '{light.contrast.palette.value."50-A32"}' },
                 // ERROR
                 'focus-error': { value: '{light.error.palette.value.45}' }
             },


### PR DESCRIPTION
Fix state-line-disabled color

<img width="471" alt="изображение" src="https://github.com/user-attachments/assets/7c72fd1b-aaa2-4779-a9fc-f1e44095ca30">

Reference
https://www.figma.com/design/y44d4NE7WYcbE9jQicsyIg/koobiq-%C2%B7-PT-2023?node-id=2195-134&node-type=frame&t=Xg1OXWP0TSKmoZhW-11