### PR TITLE
fix(checkbox): disabled border color

### DIFF
--- a/packages/design-tokens/web/components/checkbox.json5
+++ b/packages/design-tokens/web/components/checkbox.json5
@@ -34,7 +34,7 @@
                         outline: { value: '1px solid {light.states.line.focus-theme}' }
                     },
                     disabled: {
-                        border: { value: '{light.line.contrast-fade}' },
+                        border: { value: '{light.states.line.disabled}' },
                         color: { value: '{light.states.icon.disabled}' },
                         text: { value: '{light.states.foreground.disabled}' },
                         background: { value: '{light.states.background.disabled}' },
@@ -75,7 +75,7 @@
                         outline: { value: '1px solid {light.states.line.focus-error}' }
                     },
                     disabled: {
-                        border: { value: '{light.line.contrast-fade}' },
+                        border: { value: '{light.states.line.disabled}' },
                         color: { value: '{light.states.icon.disabled}' },
                         text: { value: '{light.states.foreground.disabled}' },
                         background: { value: '{light.states.background.disabled}' },


### PR DESCRIPTION
Едва заметные визуально изменения. 
Раньше для обводки неактивного чекбокса использовался цвет line-contrast-fade, в Фигме states-line-disabled
Теперь все совпадает с Фигмой буквально

<img width="487" alt="изображение" src="https://github.com/user-attachments/assets/3079fd43-9c28-4852-b99b-51037c4dec53">

Референс из Фигмы
https://www.figma.com/design/y44d4NE7WYcbE9jQicsyIg/koobiq-%C2%B7-PT-2023?node-id=7156-31903&node-type=frame&t=m0dA3xCT3hWqZmJo-11