### PR TITLE
fix(colors): states-bg-theme-less-alias (#DS-3400)

### DIFF
--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -360,7 +360,7 @@
                 'theme-active': { value: '{dark.theme.palette.value.39}' },
                 'theme-fade-hover': { value: '{dark.theme.palette.value.26}' },
                 'theme-fade-active': { value: '{dark.theme.palette.value.28}' },
-                'theme-less-hover': { value: '{dark.theme.palette.value.15}' },
+                'theme-less-hover': { value: '{dark.theme.palette.value.17}' },
                 'theme-less-active': { value: '{dark.theme.palette.value.19}' },
                 //  CONTRAST
                 'contrast-hover': { value: '{dark.contrast.palette.value.80}' },


### PR DESCRIPTION
Темная тема
states-background-theme-less-hover

В фигме и в коде цвета отличались по ошибке. В коде состояние hover не отличалось от normal, а должно. Я сделал как в фигме

![image](https://github.com/user-attachments/assets/92ead8fd-6293-4ed0-95ed-bf0c6ca2fc81)

<img width="937" alt="image" src="https://github.com/user-attachments/assets/0cbc624d-a03d-4f59-a60c-d2bddc8b6948" />
