### PR TITLE
feat(colors): add states-bg-success (#DS-3391)

### DIFF
--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -382,7 +382,7 @@
                 'warning-less-hover': { value: '{dark.warning.palette.value.11}' },
                 'warning-less-active': { value: '{dark.warning.palette.value.12}' },
                 // SUCCESS
-                'success-hover': { value: '{dark.success.palette.value.39}' },
+                'success-hover': { value: '{dark.success.palette.value.38}' },
                 'success-active': { value: '{dark.success.palette.value.35}' },
                 'success-fade-hover': { value: '{dark.success.palette.value.17}' },
                 'success-fade-active': { value: '{dark.success.palette.value.19}' },

--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -156,6 +156,8 @@
                 'error-less-hover': { value: '{light.error.palette.value.92}' },
                 'error-less-active': { value: '{light.error.palette.value.89}' },
                 //  SUCCESS
+                'success-hover': { value: '{light.success.palette.value.42}' },
+                'success-active': { value: '{light.success.palette.value.38}' },
                 'success-fade-hover': { value: '{light.success.palette.value.76}' },
                 'success-fade-active': { value: '{light.success.palette.value.84}' },
                 'success-less-hover': { value: '{light.success.palette.value.84}' },
@@ -380,6 +382,8 @@
                 'warning-less-hover': { value: '{dark.warning.palette.value.11}' },
                 'warning-less-active': { value: '{dark.warning.palette.value.12}' },
                 // SUCCESS
+                'success-hover': { value: '{dark.success.palette.value.39}' },
+                'success-active': { value: '{dark.success.palette.value.35}' },
                 'success-fade-hover': { value: '{dark.success.palette.value.17}' },
                 'success-fade-active': { value: '{dark.success.palette.value.19}' },
                 'success-less-hover': { value: '{dark.success.palette.value.11}' },


### PR DESCRIPTION
Добавить состояния для токенов background-success. Раньше их просто не было

Зеленый цвет изначально сильно отличается от базового синего по контрасту, поэтому и состояния success-токена сделаны на в соответствии с параметрами состояний синего, а скорее пытаются сохранить относительный конраст между друг другом в рамках одной зеленой палитры

![image](https://github.com/user-attachments/assets/d52dc502-ac1f-4d7c-9dee-e5dab0cb6ba1)
![image](https://github.com/user-attachments/assets/58202568-c81a-4040-888f-8eeea4960727)

