### PR TITLE
feat: add opacity.disabled tokens for toggle redesign

### DIFF
--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -222,7 +222,7 @@
                 // ERROR
                 'focus-error': { value: '{light.error.palette.value.45}' }
             },
-            'disabled-opacity': { value: 0.32, deprecated: true, deprecated_comment: 'use --kbq-opacity-disabled' }
+            'disabled-opacity': { value: '{light.opacity.disabled}', deprecated: true, deprecated_comment: 'use --kbq-opacity-disabled' }
         }
     },
     // DARK THEME
@@ -449,7 +449,7 @@
                 //  ERROR
                 'focus-error': { value: '{dark.error.palette.value.45}' }
             },
-            'disabled-opacity': { value: 0.32, deprecated: true, deprecated_comment: 'use --kbq-opacity-disabled' }
+            'disabled-opacity': { value: '{dark.opacity.disabled}', deprecated: true, deprecated_comment: 'use --kbq-opacity-disabled' }
         }
     }
 }

--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -135,6 +135,9 @@
             key: { value: '{light.contrast.palette.value."6-A6"}' },
             ambient: { value: '{light.contrast.palette.value."6-A12"}' }
         },
+        opacity: {
+            'disabled': { value: 0.32 }
+        },
         states: {
             background: {
                 //  THEME
@@ -219,7 +222,7 @@
                 // ERROR
                 'focus-error': { value: '{light.error.palette.value.45}' }
             },
-            'disabled-opacity': { value: 0.32 }
+            'disabled-opacity': { value: 0.32, deprecated: true, deprecated_comment: 'use --kbq-opacity-disabled' }
         }
     },
     // DARK THEME
@@ -359,6 +362,9 @@
             key: { value: 'transparent' },
             ambient: { value: 'transparent' }
         },
+        opacity: {
+            'disabled': { value: 0.32 }
+        },
         states: {
             background: {
                 //  THEME
@@ -443,7 +449,7 @@
                 //  ERROR
                 'focus-error': { value: '{dark.error.palette.value.45}' }
             },
-            'disabled-opacity': { value: 0.32 }
+            'disabled-opacity': { value: 0.32, deprecated: true, deprecated_comment: 'use --kbq-opacity-disabled' }
         }
     }
 }


### PR DESCRIPTION
#### Добавил токен opacity.disabled

Я планирую использовать прозрачность для нового дизайна неактивного состояния Toggle в рамках задачи DS-3861
![image](https://github.com/user-attachments/assets/65e585e9-16e1-49f8-9c10-e140a1cf27c0)

Добавил этот токен в файл colors.json. Его значением потенциально может меняться в в светлой и в темной теме. Есть сомнения, верно ли сделал, или лучше в другой файл добавить токен opacity.disabled. 

#### Депрекейтнул существующий токен 'disabled-opacity'.

Хочу чтобы токены назывались так, чтобы тип токена стоял в начале. Переменная `--kbq-states-disabled-opacity` выпадает из этой логики. Поэтому создал новую `--kbq-opacity-disabled`.

Токены цветов будут исключением, у нас исторически они без префикса (достаточно light или dark). Также цвета — это самый массовый тип токена. Ни к чему им в имени иметь строку `color`. Например, `--kbq-color-foreground-contrast`. Названия переменных цветов без этого будут короче.

По поводу депрекейтнутости, а разве не достаточно одного поля deprecated, если там строка, то она и будет являться комментом и признаком true? https://tr.designtokens.org/format/#deprecated

#### Что поменялось для юзера
Переменная `--kbq-states-disabled-opacity` переименована в `--kbq-opacity-disabled`
