### PR TITLE
feat: split tokens into separate files (#DS-3117)

### DIFF
--- a/packages/tokens-builder/configs/css.js
+++ b/packages/tokens-builder/configs/css.js
@@ -54,10 +54,42 @@ const colorPalettesConfig = [
     prefix: 'kbq'
 }));
 
+const semanticPalettesConfig = ['theme', 'success', 'warning', 'error', 'contrast', 'white', 'black', 'purple'].map(
+    (color) => ({
+        destination: `css/semantic-palette/${color}.css`,
+        format: 'kbq-css/palette',
+        filter: (token) =>
+            token.filePath.includes('colors.json5') &&
+            token.attributes.light &&
+            token.attributes.type === color &&
+            (token.attributes.palette || token.name.includes('default')),
+        prefix: 'kbq'
+    })
+);
+
 module.exports = {
     css: {
         transformGroup: 'kbq/css',
         files: [
+            ...semanticPalettesConfig,
+            {
+                destination: 'css/semantic-palette-light.css',
+                format: 'kbq-css/palette',
+                filter: (token) => token.attributes.light && token.filePath.includes('colors.json5'),
+                prefix: 'kbq',
+                options: {
+                    selector: '.kbq-light'
+                }
+            },
+            {
+                destination: 'css/semantic-palette-dark.css',
+                format: 'kbq-css/palette',
+                filter: (token) => token.attributes.dark && token.filePath.includes('colors.json5'),
+                prefix: 'kbq',
+                options: {
+                    selector: '.kbq-dark'
+                }
+            },
             {
                 destination: 'css/font.css',
                 format: 'css/variables',

--- a/packages/tokens-builder/configs/css.js
+++ b/packages/tokens-builder/configs/css.js
@@ -1,53 +1,40 @@
 const fs = require('fs');
 const path = require('node:path');
 
-const componentTokensBase = fs
+const componentTokens = fs
     .readdirSync(path.join('packages', 'design-tokens', 'web', 'components'))
     .filter((fileName) => fileName.endsWith('.json5'))
-    .map((fileName) => {
-        const componentName = fileName.replace('.json5', '');
+    .map((fileName) => fileName.replace('.json5', ''));
 
-        return {
-            destination: `css/components/${componentName}/${componentName}.css`,
-            format: 'kbq-css/variables',
-            filter: (token) => token.filePath.includes(fileName) && !token.attributes.light && !token.attributes.dark,
-            prefix: 'kbq'
-        };
-    });
+const componentTokensBase = componentTokens.map((fileName) => ({
+    destination: `css/components/${fileName}/${fileName}.css`,
+    format: 'kbq-css/variables',
+    filter: (token) => token.filePath.includes(fileName) && !token.attributes.light && !token.attributes.dark,
+    prefix: 'kbq',
+    options: {
+        outputReferences: true
+    }
+}));
 
-const componentTokensLight = fs
-    .readdirSync(path.join('packages', 'design-tokens', 'web', 'components'))
-    .filter((fileName) => fileName.endsWith('.json5'))
-    .map((fileName) => {
-        const componentName = fileName.replace('.json5', '');
+const componentTokensLight = componentTokens.map((fileName) => ({
+    destination: `css/components/${fileName}/${fileName}-light.css`,
+    format: 'kbq-css/variables',
+    filter: (token) => token.filePath.includes(fileName) && token.attributes.light,
+    prefix: 'kbq',
+    options: {
+        selector: '.kbq-light'
+    }
+}));
 
-        return {
-            destination: `css/components/${componentName}/${componentName}-light.css`,
-            format: 'kbq-css/variables',
-            filter: (token) => token.filePath.includes(fileName) && token.attributes.light,
-            prefix: 'kbq',
-            options: {
-                selector: '.kbq-light'
-            }
-        };
-    });
-
-const componentTokensDark = fs
-    .readdirSync(path.join('packages', 'design-tokens', 'web', 'components'))
-    .filter((fileName) => fileName.endsWith('.json5'))
-    .map((fileName) => {
-        const componentName = fileName.replace('.json5', '');
-
-        return {
-            destination: `css/components/${componentName}/${componentName}-dark.css`,
-            format: 'kbq-css/variables',
-            filter: (token) => token.filePath.includes(fileName) && token.attributes.dark,
-            prefix: 'kbq',
-            options: {
-                selector: '.kbq-dark'
-            }
-        };
-    });
+const componentTokensDark = componentTokens.map((fileName) => ({
+    destination: `css/components/${fileName}/${fileName}-dark.css`,
+    format: 'kbq-css/variables',
+    filter: (token) => token.filePath.includes(fileName) && token.attributes.dark,
+    prefix: 'kbq',
+    options: {
+        selector: '.kbq-dark'
+    }
+}));
 
 const colorPalettesConfig = [
     'black',
@@ -72,12 +59,26 @@ module.exports = {
         transformGroup: 'kbq/css',
         files: [
             {
-                destination: 'css/typography.css',
+                destination: 'css/font.css',
                 format: 'css/variables',
-                filter: (token) => token.attributes.category === 'typography',
+                filter: (token) => token.attributes.category === 'font',
                 prefix: 'kbq'
             },
-
+            {
+                destination: 'css/size.css',
+                format: 'css/variables',
+                filter: (token) => token.attributes.category === 'size',
+                prefix: 'kbq'
+            },
+            {
+                destination: 'css/md-typography.css',
+                format: 'css/variables',
+                filter: (token) => token.attributes.category === 'md-typography',
+                prefix: 'kbq',
+                options: {
+                    outputReferences: true
+                }
+            },
             ...colorPalettesConfig,
             {
                 destination: 'css/palette.css',
@@ -85,12 +86,21 @@ module.exports = {
                 filter: (token) => token.attributes.category === 'palette',
                 prefix: 'kbq'
             },
-            // {
-            //     destination: 'css/semantic-palette.css',
-            //     format: 'kbq-css/variables',
-            //     filter: 'palette',
-            //     prefix: 'kbq'
-            // },
+            {
+                destination: 'css/shadows.css',
+                format: 'css/variables',
+                filter: (token) => token.attributes.category === 'shadow',
+                prefix: 'kbq'
+            },
+            {
+                destination: 'css/typography.css',
+                format: 'css/variables',
+                filter: (token) => token.attributes.category === 'typography',
+                prefix: 'kbq',
+                options: {
+                    outputReferences: true
+                }
+            },
             ...componentTokensBase,
             ...componentTokensLight,
             ...componentTokensDark,

--- a/packages/tokens-builder/configs/css.js
+++ b/packages/tokens-builder/configs/css.js
@@ -174,7 +174,7 @@ module.exports = {
             ...componentTokensLight,
             ...componentTokensDark,
             {
-                destination: 'css/light/components.css',
+                destination: 'deprecated/css/components-light.css',
                 format: 'kbq-css/variables',
                 filter: (token) =>
                     token.attributes.light && !token.attributes.palette && token.filePath.includes('components'),
@@ -184,7 +184,7 @@ module.exports = {
                 }
             },
             {
-                destination: 'css/dark/components.css',
+                destination: 'deprecated/css/components-dark.css',
                 format: 'kbq-css/variables',
                 filter: (token) =>
                     token.attributes.dark && !token.attributes.palette && token.filePath.includes('components'),

--- a/packages/tokens-builder/configs/css.js
+++ b/packages/tokens-builder/configs/css.js
@@ -1,7 +1,119 @@
+const fs = require('fs');
+const path = require('node:path');
+
+const componentTokensBase = fs
+    .readdirSync(path.join('packages', 'design-tokens', 'web', 'components'))
+    .filter((fileName) => fileName.endsWith('.json5'))
+    .map((fileName) => {
+        const componentName = fileName.replace('.json5', '');
+
+        return {
+            destination: `css/components/${componentName}/${componentName}.css`,
+            format: 'kbq-css/variables',
+            filter: (token) => token.filePath.includes(fileName) && !token.attributes.light && !token.attributes.dark,
+            prefix: 'kbq'
+        };
+    });
+
+const componentTokensLight = fs
+    .readdirSync(path.join('packages', 'design-tokens', 'web', 'components'))
+    .filter((fileName) => fileName.endsWith('.json5'))
+    .map((fileName) => {
+        const componentName = fileName.replace('.json5', '');
+
+        return {
+            destination: `css/components/${componentName}/${componentName}-light.css`,
+            format: 'kbq-css/variables',
+            filter: (token) => token.filePath.includes(fileName) && token.attributes.light,
+            prefix: 'kbq',
+            options: {
+                selector: '.kbq-light'
+            }
+        };
+    });
+
+const componentTokensDark = fs
+    .readdirSync(path.join('packages', 'design-tokens', 'web', 'components'))
+    .filter((fileName) => fileName.endsWith('.json5'))
+    .map((fileName) => {
+        const componentName = fileName.replace('.json5', '');
+
+        return {
+            destination: `css/components/${componentName}/${componentName}-dark.css`,
+            format: 'kbq-css/variables',
+            filter: (token) => token.filePath.includes(fileName) && token.attributes.dark,
+            prefix: 'kbq',
+            options: {
+                selector: '.kbq-dark'
+            }
+        };
+    });
+
+const colorPalettesConfig = [
+    'black',
+    'blue',
+    'cyan',
+    'green',
+    'grey',
+    'orange',
+    'purple',
+    'red',
+    'white',
+    'yellow'
+].map((color) => ({
+    destination: `css/palette/${color}.css`,
+    format: 'kbq-css/variables',
+    filter: (token) => token.attributes.category === 'palette' && token.attributes.type === color,
+    prefix: 'kbq'
+}));
+
 module.exports = {
     css: {
         transformGroup: 'kbq/css',
         files: [
+            {
+                destination: 'css/typography.css',
+                format: 'css/variables',
+                filter: (token) => token.attributes.category === 'typography',
+                prefix: 'kbq'
+            },
+
+            ...colorPalettesConfig,
+            {
+                destination: 'css/palette.css',
+                format: 'kbq-css/variables',
+                filter: (token) => token.attributes.category === 'palette',
+                prefix: 'kbq'
+            },
+            // {
+            //     destination: 'css/semantic-palette.css',
+            //     format: 'kbq-css/variables',
+            //     filter: 'palette',
+            //     prefix: 'kbq'
+            // },
+            ...componentTokensBase,
+            ...componentTokensLight,
+            ...componentTokensDark,
+            {
+                destination: 'css/components-light.css',
+                format: 'kbq-css/variables',
+                filter: (token) =>
+                    token.attributes.light && !token.attributes.palette && token.filePath.includes('components'),
+                prefix: 'kbq',
+                options: {
+                    selector: '.kbq-light'
+                }
+            },
+            {
+                destination: 'css/components-dark.css',
+                format: 'kbq-css/variables',
+                filter: (token) =>
+                    token.attributes.dark && !token.attributes.palette && token.filePath.includes('components'),
+                prefix: 'kbq',
+                options: {
+                    selector: '.kbq-dark'
+                }
+            },
             {
                 destination: 'css-tokens.css',
                 format: 'css/variables',

--- a/packages/tokens-builder/configs/css.js
+++ b/packages/tokens-builder/configs/css.js
@@ -1,13 +1,21 @@
 const fs = require('fs');
 const path = require('node:path');
 
+const paletteColors = ['black', 'blue', 'cyan', 'green', 'grey', 'orange', 'purple', 'red', 'white', 'yellow'];
+const semanticPaletteColors = ['theme', 'success', 'warning', 'error', 'contrast', 'white', 'black', 'purple'];
+
+// resolve components path if script used externally
+const componentsPath = fs.existsSync(path.join('node_modules', '@koobiq/design-tokens', 'web', 'components'))
+    ? path.join('node_modules', '@koobiq/design-tokens', 'web', 'components')
+    : path.join('packages', 'design-tokens', 'web', 'components');
+
 const componentTokens = fs
-    .readdirSync(path.join('packages', 'design-tokens', 'web', 'components'))
+    .readdirSync(componentsPath)
     .filter((fileName) => fileName.endsWith('.json5'))
     .map((fileName) => fileName.replace('.json5', ''));
 
 const componentTokensBase = componentTokens.map((fileName) => ({
-    destination: `css/components/${fileName}/${fileName}.css`,
+    destination: `deprecated/css/components/${fileName}/${fileName}.css`,
     format: 'kbq-css/variables',
     filter: (token) => token.filePath.includes(fileName) && !token.attributes.light && !token.attributes.dark,
     prefix: 'kbq',
@@ -17,7 +25,7 @@ const componentTokensBase = componentTokens.map((fileName) => ({
 }));
 
 const componentTokensLight = componentTokens.map((fileName) => ({
-    destination: `css/components/${fileName}/${fileName}-light.css`,
+    destination: `deprecated/css/components/${fileName}/${fileName}-light.css`,
     format: 'kbq-css/variables',
     filter: (token) => token.filePath.includes(fileName) && token.attributes.light,
     prefix: 'kbq',
@@ -27,7 +35,7 @@ const componentTokensLight = componentTokens.map((fileName) => ({
 }));
 
 const componentTokensDark = componentTokens.map((fileName) => ({
-    destination: `css/components/${fileName}/${fileName}-dark.css`,
+    destination: `deprecated/css/components/${fileName}/${fileName}-dark.css`,
     format: 'kbq-css/variables',
     filter: (token) => token.filePath.includes(fileName) && token.attributes.dark,
     prefix: 'kbq',
@@ -36,55 +44,72 @@ const componentTokensDark = componentTokens.map((fileName) => ({
     }
 }));
 
-const colorPalettesConfig = [
-    'black',
-    'blue',
-    'cyan',
-    'green',
-    'grey',
-    'orange',
-    'purple',
-    'red',
-    'white',
-    'yellow'
-].map((color) => ({
+const paletteByColorsConfig = paletteColors.map((color) => ({
     destination: `css/palette/${color}.css`,
     format: 'kbq-css/variables',
     filter: (token) => token.attributes.category === 'palette' && token.attributes.type === color,
     prefix: 'kbq'
 }));
 
-const semanticPalettesConfig = ['theme', 'success', 'warning', 'error', 'contrast', 'white', 'black', 'purple'].map(
-    (color) => ({
-        destination: `css/semantic-palette/${color}.css`,
-        format: 'kbq-css/palette',
-        filter: (token) =>
-            token.filePath.includes('colors.json5') &&
-            token.attributes.light &&
-            token.attributes.type === color &&
-            (token.attributes.palette || token.name.includes('default')),
-        prefix: 'kbq'
-    })
-);
+const semanticPaletteConfig = semanticPaletteColors.map((color) => ({
+    destination: `css/semantic-palette/${color}.css`,
+    format: 'kbq-css/palette',
+    filter: (token) =>
+        token.filePath.includes('colors.json5') &&
+        token.attributes.light &&
+        token.attributes.type === color &&
+        (token.attributes.palette || token.name.includes('default')),
+    prefix: 'kbq'
+}));
 
 module.exports = {
     css: {
         transformGroup: 'kbq/css',
         files: [
-            ...semanticPalettesConfig,
+            ...semanticPaletteConfig,
             {
-                destination: 'css/semantic-palette-light.css',
+                destination: 'css/light/semantic-palette.css',
                 format: 'kbq-css/palette',
-                filter: (token) => token.attributes.light && token.filePath.includes('colors.json5'),
+                filter: (token) =>
+                    token.attributes.light &&
+                    token.filePath.includes('colors.json5') &&
+                    (token.attributes.palette || token.name.includes('default')),
                 prefix: 'kbq',
                 options: {
                     selector: '.kbq-light'
                 }
             },
             {
-                destination: 'css/semantic-palette-dark.css',
+                destination: 'css/dark/semantic-palette.css',
                 format: 'kbq-css/palette',
-                filter: (token) => token.attributes.dark && token.filePath.includes('colors.json5'),
+                filter: (token) =>
+                    token.attributes.dark &&
+                    token.filePath.includes('colors.json5') &&
+                    (token.attributes.palette || token.name.includes('default')),
+                prefix: 'kbq',
+                options: {
+                    selector: '.kbq-dark'
+                }
+            },
+            {
+                destination: 'css/light/semantic-colors.css',
+                format: 'kbq-css/palette',
+                filter: (token) =>
+                    token.attributes.light &&
+                    token.filePath.includes('colors.json5') &&
+                    !semanticPaletteColors.includes(token.attributes.type),
+                prefix: 'kbq',
+                options: {
+                    selector: '.kbq-light'
+                }
+            },
+            {
+                destination: 'css/dark/semantic-colors.css',
+                format: 'kbq-css/palette',
+                filter: (token) =>
+                    token.attributes.dark &&
+                    token.filePath.includes('colors.json5') &&
+                    !semanticPaletteColors.includes(token.attributes.type),
                 prefix: 'kbq',
                 options: {
                     selector: '.kbq-dark'
@@ -111,7 +136,7 @@ module.exports = {
                     outputReferences: true
                 }
             },
-            ...colorPalettesConfig,
+            ...paletteByColorsConfig,
             {
                 destination: 'css/palette.css',
                 format: 'kbq-css/variables',
@@ -119,10 +144,22 @@ module.exports = {
                 prefix: 'kbq'
             },
             {
-                destination: 'css/shadows.css',
-                format: 'css/variables',
-                filter: (token) => token.attributes.category === 'shadow',
-                prefix: 'kbq'
+                destination: 'css/light/shadows.css',
+                format: 'kbq-css/variables',
+                filter: (token) => token.attributes.light && token.attributes.category === 'shadow',
+                prefix: 'kbq',
+                options: {
+                    selector: '.kbq-light'
+                }
+            },
+            {
+                destination: 'css/dark/shadows.css',
+                format: 'kbq-css/variables',
+                filter: (token) => token.attributes.dark && token.attributes.category === 'shadow',
+                prefix: 'kbq',
+                options: {
+                    selector: '.kbq-dark'
+                }
             },
             {
                 destination: 'css/typography.css',
@@ -137,7 +174,7 @@ module.exports = {
             ...componentTokensLight,
             ...componentTokensDark,
             {
-                destination: 'css/components-light.css',
+                destination: 'css/light/components.css',
                 format: 'kbq-css/variables',
                 filter: (token) =>
                     token.attributes.light && !token.attributes.palette && token.filePath.includes('components'),
@@ -147,7 +184,7 @@ module.exports = {
                 }
             },
             {
-                destination: 'css/components-dark.css',
+                destination: 'css/dark/components.css',
                 format: 'kbq-css/variables',
                 filter: (token) =>
                     token.attributes.dark && !token.attributes.palette && token.filePath.includes('components'),

--- a/packages/tokens-builder/formats/utils.js
+++ b/packages/tokens-builder/formats/utils.js
@@ -1,6 +1,6 @@
 const transform = require('style-dictionary/lib/common/transforms');
 
-const unwrapObjectTransformer = (token) => {
+const unwrapObjectTransformer = (token, additionalAttrs = {}) => {
     return Object.keys(token.value).map((key) => {
         const subToken = token.value[key];
         const res = {
@@ -10,7 +10,7 @@ const unwrapObjectTransformer = (token) => {
             name: `kbq-${[...token.path, key].join('-')}`,
             original: { value: subToken }
         };
-        res.attributes = { ...transform['attribute/cti'].transformer(res), font: true };
+        res.attributes = { ...transform['attribute/cti'].transformer(res), ...additionalAttrs };
         return res;
     }, {});
 };

--- a/packages/tokens-builder/formats/variables.js
+++ b/packages/tokens-builder/formats/variables.js
@@ -10,7 +10,7 @@ module.exports = (StyleDictionary) => {
             // apply custom transformations for tokens
             dictionary.allProperties = dictionary.allTokens = dictionary.allTokens.flatMap((token) => {
                 if (typeof token.value === 'object' && token.type === 'font') {
-                    return unwrapObjectTransformer(token);
+                    return unwrapObjectTransformer(token, { font: true });
                 }
                 return token;
             });

--- a/packages/tokens-builder/formats/variables.js
+++ b/packages/tokens-builder/formats/variables.js
@@ -27,4 +27,30 @@ module.exports = (StyleDictionary) => {
             );
         }
     });
+
+    StyleDictionary.registerFormat({
+        name: 'kbq-css/palette',
+        formatter: function ({ dictionary, options = {}, file }) {
+            const { outputReferences, selector = ':root' } = options;
+
+            dictionary.allProperties = dictionary.allTokens = dictionary.allTokens.flatMap((token) => {
+                if (typeof token.value === 'object') {
+                    return unwrapObjectTransformer(token);
+                }
+                return token;
+            });
+
+            dictionary.allTokens.forEach((token) => {
+                token.name = token.name.replace(/(light|dark)-/, '');
+                token.name = token.name.replace(/"/g, '');
+            });
+
+            return (
+                formatHelpers.fileHeader({ file }) +
+                `${selector} {\n` +
+                formatHelpers.formattedVariables({ format: 'css', dictionary, outputReferences }) +
+                `\n}\n`
+            );
+        }
+    });
 };


### PR DESCRIPTION
- Разделил дизайн-токены на разные файлы, чтобы можно было подключать атомарно. Можно подключить семантическую или инженерную палетку для каждого цвета отдельно (в подпапках `semantic-palette` и `palette`), либо весь набор цветов. 

- Переменные, у которых есть `dark` / `light` режим, положил в соответствующие папки.

- Подключил вывод референсов в некоторых файлах:
   - md-typography,
   - typography
   - файл с размерами/шрифтами компонентов.

 В остальных файлах нужно разбираться с референсами семантической палатки (ситуация с двойным референсом (Например shadow-type -> semantic color -> palette color).

Как выглядит обновленная структура

|    | |
| -------- | ------- |
| <img width="244" height="620" alt="image" src="https://github.com/user-attachments/assets/dea76272-63a3-4acf-9019-896516cb9b37" />  | $<img width="341" height="649" alt="image" src="https://github.com/user-attachments/assets/e5ac5762-bce5-46ed-bd6a-f86d74e5ff83" />    |




