### PR TITLE
feat(skeleton): new palette colors (#DS-4887)

### DIFF
--- a/packages/design-tokens/web/components/skeleton.json5
+++ b/packages/design-tokens/web/components/skeleton.json5
@@ -1,22 +1,22 @@
 {
     'skeleton': {
         light: {
-            background: { value:  '{light.contrast.palette.value."0-A8"}'},
+            background: { value:  '{light.background.contrast-less}'},
             animation: {
                 wave: {
-                    start: { value:  '{light.contrast.palette.value."0-A0"}'},
-                    center: { value:  '{light.contrast.palette.value."0-A8"}'},
-                    end: { value:  '{light.contrast.palette.value."0-A0"}'}
+                    start: { value:  'oklch(0 0 0 / 0)'},
+                    center: { value:  '{plt.blackA.2}'},
+                    end: { value:  'oklch(0 0 0 / 0)'}
                 }
             }
         },
         dark: {
-            background: { value:  '{light.contrast.palette.value."100-A8"}'},
+            background: { value:  '{dark.background.contrast-less}'},
             animation: {
                 wave: {
-                    start: { value:  '{light.contrast.palette.value."100-A0"}'},
-                    center: { value:  '{light.contrast.palette.value."100-A8"}'},
-                    end: { value:  '{light.contrast.palette.value."100-A0"}'}
+                    start: { value:  'oklch(1 0 0 / 0)'},
+                    center: { value:  '{plt.whiteA.1}'},
+                    end: { value:  'oklch(1 0 0 / 0)'}
                 }
             }
         }


### PR DESCRIPTION
Применил к компонентным токенам скелетона цвета из новой палитры

<img width="600" height="200" alt="image" src="https://github.com/user-attachments/assets/8c71e78a-2fa0-47a1-8108-bff0b5f78f42" />
