### PR TITLE
fix: overlay theme and error in dark theme (#DS-4914)

### DIFF
--- a/packages/design-tokens/web/properties/colors.json5
+++ b/packages/design-tokens/web/properties/colors.json5
@@ -705,10 +705,10 @@
                 "value": "{plt.blackA.18}"
             },
             "overlay-theme": {
-                "value": "{semantic.darkThemeA.18}"
+                "value": "{semantic.darkThemeA.4}"
             },
             "overlay-error": {
-                "value": "{semantic.darkErrorA.18}"
+                "value": "{semantic.darkErrorA.4}"
             },
             "overlay-inverse": {
                 "value": "{plt.blackA.18}"


### PR DESCRIPTION
Цвет background.overlay-theme, overlay-error в темной теме

<img width="2024" height="926" alt="image" src="https://github.com/user-attachments/assets/083d157b-6955-4485-92ef-140b0c592b88" />
