### PR TITLE
fix: remove redundant chars from output

### DIFF
--- a/packages/tokens-builder/transforms/name/custom-kebab.js
+++ b/packages/tokens-builder/transforms/name/custom-kebab.js
@@ -8,6 +8,7 @@ module.exports = (StyleDictionary) => {
                     part
                         .replace(/([a-z])([A-Z])/g, '$1-$2')
                         .replace(/"/g, '')
+                        .replace(/[\s.]+/g, '-')
                         .toLowerCase()
                 )
                 .join('-');


### PR DESCRIPTION
fix name of properties with non-standard name

- 'meta keyword'` → `meta-keyword`
- `'meta.prompt'` → `meta-prompt`  
- `'title.class.inherited'` → `title-class-inherited`
- `'variable.constant'` → `variable-constant