### PR TITLE
fix: dark‑theme bg‑overlay color (DS‑5140)

### DIFF
--- a/packages/design-tokens/web/properties/colors.v2.json5
+++ b/packages/design-tokens/web/properties/colors.v2.json5
@@ -737,7 +737,7 @@
                 "value": "#00000000"
             },
             "overlay": {
-                "value": "{plt.blackA.12}"
+                "value": "{plt.blackA.15}"
             },
             "overlay-theme": {
                 "value": "{semantic.darkThemeA.4}"
@@ -746,7 +746,7 @@
                 "value": "{semantic.darkErrorA.4}"
             },
             "overlay-inverse": {
-                "value": "{plt.blackA.12}"
+                "value": "{plt.blackA.15}"
             },
             "highlight": {
                 "value": "{plt.darkYellowA.5}"

--- a/packages/design-tokens/web/properties/colors.v2.json5
+++ b/packages/design-tokens/web/properties/colors.v2.json5
@@ -737,7 +737,7 @@
                 "value": "#00000000"
             },
             "overlay": {
-                "value": "{plt.blackA.18}"
+                "value": "{plt.blackA.12}"
             },
             "overlay-theme": {
                 "value": "{semantic.darkThemeA.4}"
@@ -746,7 +746,7 @@
                 "value": "{semantic.darkErrorA.4}"
             },
             "overlay-inverse": {
-                "value": "{plt.blackA.18}"
+                "value": "{plt.blackA.12}"
             },
             "highlight": {
                 "value": "{plt.darkYellowA.5}"


### PR DESCRIPTION
Оверлей был слишком непрозрачным в темной теме. У overlay-inverse такая же проблема. Токены стали более прозрачными.
Closes #DS‑5140

<img width="1248" height="440" alt="image" src="https://github.com/user-attachments/assets/06851c90-9277-43ca-890a-5116fed750e1" />


