### PR TITLE
feat: add index.css entry point for separated token files (#DS-5265)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,61 @@ Here’s a clearer and more structured version for both developers and designers
 
 ---
 
+## 🎨 Using the tokens in your app
+
+The package ships ready-made CSS entry points so you don't have to wire up individual token files. Two output tracks are available:
+
+- `web/new/` — **OKLch** colors (recommended)
+- `web/css/` — legacy **HSL** colors (backward compatibility)
+
+Each track provides two entry points:
+
+- **`index.bundled.css`** — every token flattened into a single stylesheet. **Use this in production** — it's one request, avoids the `@import` waterfall, and is deduplicated.
+- **`index.css`** — a thin manifest that `@import`s the individual token files. Handy for development or when you want to cherry-pick/override specific files.
+
+### Import
+
+Production (single file, recommended):
+
+```css
+@import '@koobiq/design-tokens/web/new/index.bundled.css';
+```
+
+Or the manifest of individual imports:
+
+```css
+@import '@koobiq/design-tokens/web/new/index.css';
+```
+
+Legacy HSL track works the same way:
+
+```css
+@import '@koobiq/design-tokens/web/css/index.bundled.css';
+```
+
+> **Only need some tokens?** Check `index.css` to see what's available and import just the files you need (e.g. `palette.css`, `light/semantic-colors.css`) instead of the full bundle.
+
+### Apply a theme
+
+Tokens expose light and dark values under `.kbq-light` / `.kbq-dark`. Add the class to a root element:
+
+```html
+<body class="kbq-light">
+    <!-- or class="kbq-dark" -->
+</body>
+```
+
+Then reference the CSS variables in your styles — never hardcode values:
+
+```css
+.card {
+    color: var(--kbq-foreground-contrast);
+    background: var(--kbq-background-theme);
+}
+```
+
+> The OKLch entry point pulls the color-agnostic tokens (font, size, typography) from the sibling `web/css` track, so both directories ship together in the package.
+
 ## 🚀 Releasing Packages
 
 **🔹 Only maintainers should perform releases.**  

--- a/packages/tokens-builder/actions/css-index.js
+++ b/packages/tokens-builder/actions/css-index.js
@@ -41,10 +41,9 @@ module.exports = (StyleDictionary) => {
 
             fs.writeFileSync(path.join(indexDir, 'index.css'), `${HEADER}\n${imports}\n`);
 
-            // Concatenating the files verbatim would repeat the `:root` / `.kbq-light` /
-            // `.kbq-dark` selectors, so group every declaration under a single block per
-            // selector. Custom properties are deduped with the last declaration winning, which
-            // mirrors how the cascade resolves the `@import` order used by index.css.
+            // Merge all declarations into one block per selector, so `:root` / `.kbq-light` /
+            // `.kbq-dark` aren't repeated. On duplicate properties the last one wins, matching
+            // the `@import` order in index.css.
             const blockRegex = /([^{}]+)\{([^}]*)\}/g;
             const selectors = [];
             const declsBySelector = new Map();

--- a/packages/tokens-builder/actions/css-index.js
+++ b/packages/tokens-builder/actions/css-index.js
@@ -44,12 +44,13 @@ module.exports = (StyleDictionary) => {
             // Merge all declarations into one block per selector, so `:root` / `.kbq-light` /
             // `.kbq-dark` aren't repeated. On duplicate properties the last one wins, matching
             // the `@import` order in index.css.
-            const blockRegex = /([^{}]+)\{([^}]*)\}/g;
             const selectors = [];
             const declsBySelector = new Map();
 
             for (const dest of files) {
                 const content = fs.readFileSync(path.join(buildPath, dest), 'utf8');
+                // A fresh regex per file keeps its `lastIndex` from carrying over between files.
+                const blockRegex = /([^{}]+)\{([^}]*)\}/g;
                 let match;
 
                 while ((match = blockRegex.exec(content)) !== null) {

--- a/packages/tokens-builder/actions/css-index.js
+++ b/packages/tokens-builder/actions/css-index.js
@@ -1,0 +1,95 @@
+const fs = require('fs');
+const path = require('node:path');
+
+const HEADER = '/**\n * Do not edit directly\n */\n';
+
+/**
+ * Generates a pair of consumer entry points for a CSS platform:
+ *
+ *   index.css — thin file that `@import`s every curated token file
+ *   index.bundled.css — the same files concatenated into a single stylesheet
+ *
+ * The list of files to include (and where the index is written) is read from the
+ * platform's `index` config so each track can curate its own aggregate set:
+ *
+ *   css: {
+ *       transformGroup: 'kbq/css',
+ *       actions: ['kbq/css-index'],
+ *       index: {
+ *           dir: 'css',                 // where index files are written (relative to buildPath)
+ *           files: ['css/font.css', …]  // token files to include (relative to buildPath)
+ *       },
+ *       files: [ … ]
+ *   }
+ */
+module.exports = (StyleDictionary) => {
+    StyleDictionary.registerAction({
+        name: 'kbq/css-index',
+        do: (_dictionary, config) => {
+            if (!config.index) {
+                return;
+            }
+
+            const { dir = '', files } = config.index;
+            const buildPath = config.buildPath;
+            const indexDir = path.join(buildPath, dir);
+
+            const imports = files
+                .map((dest) => path.relative(indexDir, path.join(buildPath, dest)).split(path.sep).join('/'))
+                .map((rel) => `@import '${rel.startsWith('../') ? rel : `./${rel}`}';`)
+                .join('\n');
+
+            fs.writeFileSync(path.join(indexDir, 'index.css'), `${HEADER}\n${imports}\n`);
+
+            // Concatenating the files verbatim would repeat the `:root` / `.kbq-light` /
+            // `.kbq-dark` selectors, so group every declaration under a single block per
+            // selector. Custom properties are deduped with the last declaration winning, which
+            // mirrors how the cascade resolves the `@import` order used by index.css.
+            const blockRegex = /([^{}]+)\{([^}]*)\}/g;
+            const selectors = [];
+            const declsBySelector = new Map();
+
+            for (const dest of files) {
+                const content = fs.readFileSync(path.join(buildPath, dest), 'utf8');
+                let match;
+
+                while ((match = blockRegex.exec(content)) !== null) {
+                    const selector = match[1].trim();
+
+                    if (!declsBySelector.has(selector)) {
+                        selectors.push(selector);
+                        declsBySelector.set(selector, new Map());
+                    }
+
+                    const decls = declsBySelector.get(selector);
+
+                    for (const rawLine of match[2].split('\n')) {
+                        const line = rawLine.trim();
+
+                        if (!line) {
+                            continue;
+                        }
+
+                        const property = line.match(/^(--[\w-]+)\s*:/);
+                        // Re-insert so the last declaration wins and keeps its position.
+                        const key = property ? property[1] : `@line-${decls.size}`;
+
+                        decls.delete(key);
+                        decls.set(key, line);
+                    }
+                }
+            }
+
+            const bundled = selectors
+                .map((selector) => {
+                    const body = [...declsBySelector.get(selector).values()].map((line) => `  ${line}`).join('\n');
+
+                    return `${selector} {\n${body}\n}`;
+                })
+                .join('\n\n');
+
+            fs.writeFileSync(path.join(indexDir, 'index.bundled.css'), `${HEADER}\n${bundled}\n`);
+        },
+        undo: () => {}
+    });
+};

--- a/packages/tokens-builder/build.js
+++ b/packages/tokens-builder/build.js
@@ -29,6 +29,9 @@ require('./formats/typography')(StyleDictionary);
 require('./formats/palette')(StyleDictionary);
 require('./formats/variables')(StyleDictionary);
 
+// ==== Include custom actions ====
+require('./actions/css-index')(StyleDictionary);
+
 // ==== Run build ====
 console.log('Build started...');
 console.log('==============================================');

--- a/packages/tokens-builder/configs/css-new.js
+++ b/packages/tokens-builder/configs/css-new.js
@@ -100,6 +100,26 @@ const newSemanticPaletteConfig = newSemanticPaletteColors.map((color) => ({
 module.exports = {
     css: {
         transformGroup: 'kbq/css-new',
+        actions: ['kbq/css-index'],
+        // OKLch entry point. Font/size/typography are color-agnostic and identical across tracks,
+        // so they are pulled from the sibling web/css track (../css) instead of being duplicated
+        // here. Per-color palette/semantic-palette splits are omitted since their variables are
+        // already covered by the aggregate palette.css / semantic-palette.css.
+        index: {
+            dir: '',
+            files: [
+                '../css/font.css',
+                '../css/size.css',
+                '../css/typography.css',
+                '../css/md-typography.css',
+                'palette.css',
+                'semantic-palette.css',
+                'light/semantic-colors.css',
+                'light/shadows.css',
+                'dark/semantic-colors.css',
+                'dark/shadows.css'
+            ]
+        },
         files: [
             ...newSemanticPaletteConfig,
             ...newPaletteByColorsConfig,

--- a/packages/tokens-builder/configs/css.js
+++ b/packages/tokens-builder/configs/css.js
@@ -68,6 +68,26 @@ const semanticPaletteConfig = semanticPaletteColors.map((color) => ({
 module.exports = {
     css: {
         transformGroup: 'kbq/css',
+        actions: ['kbq/css-index'],
+        // Curated aggregate token files consumers can pull in via a single entry point.
+        // Per-color palette splits, root css-tokens*.css and deprecated component tokens are
+        // intentionally excluded to avoid duplicate variable declarations.
+        index: {
+            dir: 'css',
+            files: [
+                'css/font.css',
+                'css/size.css',
+                'css/typography.css',
+                'css/md-typography.css',
+                'css/palette.css',
+                'css/light/semantic-palette.css',
+                'css/light/semantic-colors.css',
+                'css/light/shadows.css',
+                'css/dark/semantic-palette.css',
+                'css/dark/semantic-colors.css',
+                'css/dark/shadows.css'
+            ]
+        },
         files: [
             ...semanticPaletteConfig,
             {


### PR DESCRIPTION
### Add single-file CSS entry points (index.css + index.bundled.css)

Simplified usage of individual CSS files.

- index.css — a thin manifest that @imports the curated token files. Human-readable, easy to see what's included, imports resolve individually.
- index.bundled.css — every token flattened into one stylesheet.

Since separated files was added to reduce deprecated tokens usage, in this PR provided better usage of a new css files