### PR TITLE
fix: increase icon hover contrast (#DS-4986)

### DIFF
--- a/packages/design-tokens/web/properties/colors.v1.json5
+++ b/packages/design-tokens/web/properties/colors.v1.json5
@@ -432,10 +432,10 @@
                     "value": "{light.contrast.palette.value.\"60-A60\"}",
                 },
                 "contrast-hover": {
-                    "value": "{light.contrast.palette.value.10}",
+                    "value": "{light.contrast.palette.value.50}",
                 },
                 "contrast-active": {
-                    "value": "{light.contrast.palette.value.10}",
+                    "value": "{light.contrast.palette.value.60}",
                 },
                 "contrast-fade-hover": {
                     "value": "{light.contrast.palette.value.50}",
@@ -921,7 +921,7 @@
                     "value": "{dark.contrast.palette.value.90}",
                 },
                 "contrast-active": {
-                    "value": "{dark.contrast.palette.value.80}",
+                    "value": "{dark.contrast.palette.value.99}",
                 },
                 "contrast-fade-hover": {
                     "value": "{dark.contrast.palette.value.50}",

--- a/packages/design-tokens/web/properties/colors.v2.json5
+++ b/packages/design-tokens/web/properties/colors.v2.json5
@@ -512,10 +512,10 @@
                     "value": "{semantic.contrastA.7}"
                 },
                 "contrast-hover": {
-                    "value": "{semantic.contrastA.19}"
+                    "value": "{semantic.contrastA.16}"
                 },
                 "contrast-active": {
-                    "value": "{semantic.contrastA.16}"
+                    "value": "{semantic.contrastA.14}"
                 },
                 "contrast-fade-hover": {
                     "value": "{semantic.contrastA.11}"
@@ -1083,10 +1083,10 @@
                     "value": "{semantic.darkContrastA.9}"
                 },
                 "contrast-hover": {
-                    "value": "{semantic.darkContrastA.19}"
+                    "value": "{semantic.darkContrastA.16}"
                 },
                 "contrast-active": {
-                    "value": "{semantic.darkContrastA.13}"
+                    "value": "{semantic.darkContrastA.14}"
                 },
                 "contrast-fade-hover": {
                     "value": "{semantic.darkContrastA.12}"


### PR DESCRIPTION
## Что сделано

- Обновлены значения `icon-contrast` для hover и active в legacy и новой палитрах.
- Учтены светлая и тёмная темы.

## Проверки

- `yarn build`